### PR TITLE
chore: remove switch dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "react-swipeable": "^7.0.2",
         "shadcn": "^2.10.0",
         "sonner": "^2.0.7",
-        "switch": "^0.0.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "winston": "^3.17.0"
@@ -15103,11 +15102,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/switch": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/switch/-/switch-0.0.0.tgz",
-      "integrity": "sha512-Pvi4hlAXWHEIT+4XlQEPPIQ02hRzvn38K/cnZ5sZeM11FsDPoXvBD6i/zyVxFK6cgqSlS8sA5/sIwUGp9+ZMhw=="
     },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "react-swipeable": "^7.0.2",
     "shadcn": "^2.10.0",
     "sonner": "^2.0.7",
-    "switch": "^0.0.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "winston": "^3.17.0"


### PR DESCRIPTION
## Summary
- drop unused `switch` package from dependencies
- refresh lockfile after removing dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf04607b008333b612b41dbf462b41