### PR TITLE
refactor: remove debug log from FCM hook

### DIFF
--- a/src/lib/notifications/useFcm.ts
+++ b/src/lib/notifications/useFcm.ts
@@ -79,8 +79,6 @@ export function useFcm() {
         return null;
       }
 
-      console.log('[vapid length]', (process.env.NEXT_PUBLIC_VAPID_KEY ?? '').trim().length);
-
       const vapidKey = process.env.NEXT_PUBLIC_VAPID_KEY!;
       if (!vapidKey) {
         console.warn('[FCM] Missing NEXT_PUBLIC_VAPID_KEY');


### PR DESCRIPTION
## Summary
- remove debug console output around FCM VAPID key retrieval

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf045ff7d083338f7fc1afc25a7350