### PR TITLE
fix: center delivery form dialog

### DIFF
--- a/src/app/components/DeliveryFormDialog.tsx
+++ b/src/app/components/DeliveryFormDialog.tsx
@@ -509,7 +509,7 @@ export default function DeliveryFormDialog({ open, onOpenChange, familyId, deliv
         {/* Remove outer motion wrapper to avoid breaking Radix centering */}
         <DialogContent
           aria-describedby={undefined}
-          className="relative max-h-[90vh] overflow-y-auto"
+          className="max-h-[90vh] overflow-y-auto"
         >
           <DialogHeader>
             <DialogTitle>{isEdit ? 'Edit Delivery' : 'Add Delivery'}</DialogTitle>


### PR DESCRIPTION
## Summary
- remove relative positioning so `DeliveryFormDialog` centers correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0c1e66148333a308e0b6e624c585