### PR TITLE
Add NEXT_PUBLIC_VAPID_KEY to vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -43,6 +43,7 @@
     "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET": "@next_public_firebase_storage_bucket",
     "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID": "@next_public_firebase_messaging_sender_id",
     "NEXT_PUBLIC_FIREBASE_APP_ID": "@next_public_firebase_app_id",
-    "NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID": "@next_public_firebase_measurement_id"
+    "NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID": "@next_public_firebase_measurement_id",
+    "NEXT_PUBLIC_VAPID_KEY": "@next_public_vapid_key"
   }
 }


### PR DESCRIPTION
## Summary
- expose `NEXT_PUBLIC_VAPID_KEY` via Vercel env config

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0ffe50c883338720ea9c0827386c