### PR TITLE
fix: redirect after joining family

### DIFF
--- a/src/app/(main)/family/join/FamilyJoinPageContent.tsx
+++ b/src/app/(main)/family/join/FamilyJoinPageContent.tsx
@@ -219,7 +219,7 @@ export default function FamilyJoinPageContent() {
       } catch {}
 
       toast.success('Joined family!')
-      router.replace(`/(main)?joined=1&family=${encodeURIComponent(familyId)}`)
+      router.replace(`/?joined=1&family=${encodeURIComponent(familyId)}`)
     } catch (e: any) {
       console.error('[join] failed', e)
       const msg =


### PR DESCRIPTION
## Summary
- ensure invite join page redirects to home with family id after a successful join

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0c905c6c8333af58cd4f188f1017