### PR TITLE
fix(auth): redirect-based Google sign-in for mobile/PWA

### DIFF
--- a/src/app/components/LoginButton.tsx
+++ b/src/app/components/LoginButton.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
-import { auth, provider } from '@/lib/firebase'
-import { signInWithPopup } from 'firebase/auth'
+import { signInWithGoogle } from '@/lib/auth-signin'
 import { useState } from 'react'
 import { FcGoogle } from 'react-icons/fc'
 import { HomeIcon, MapPinIcon, PackageIcon, ShieldIcon } from 'lucide-react'
@@ -36,8 +35,8 @@ export default function LoginButton() {
   const handleLogin = async () => {
     setLoading(true)
     try {
-      await signInWithPopup(auth, provider)
-      // layout handles redirect
+      await signInWithGoogle()
+      // layout handles redirect (desktop popup); mobile navigates away via redirect
     } catch (err) {
       console.error('Login failed:', err)
     } finally {

--- a/src/app/login/_components/LoginPage.tsx
+++ b/src/app/login/_components/LoginPage.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
-import { auth, provider, firestore } from '@/lib/firebase'
-import { signInWithPopup } from 'firebase/auth'
+import { firestore } from '@/lib/firebase'
+import { signInWithGoogle } from '@/lib/auth-signin'
 import { useEffect, useRef, useState } from 'react'
 import { FcGoogle } from 'react-icons/fc'
 import { HomeIcon, MapPinIcon, PackageIcon, ShieldIcon, Loader2 } from 'lucide-react'
@@ -37,7 +37,8 @@ export default function LoginPage() {
   useEffect(() => {
     if (authLoading) return
     if (!user) return
-    if (redirect === null && invite === null) return
+    // Route any signed-in user onward — including after a mobile redirect
+    // sign-in returns to /login with no redirect/invite param.
     if (redirectedRef.current) return
 
     const go = async () => {
@@ -72,7 +73,9 @@ export default function LoginPage() {
   async function handleLogin() {
     setLoading(true)
     try {
-      await signInWithPopup(auth, provider)
+      await signInWithGoogle()
+      // On desktop (popup) auth resolves here and useAuth handles the rest.
+      // On mobile (redirect) the page navigates away before reaching this point.
     } catch (err) {
       console.error('Login failed:', err)
       setLoading(false)

--- a/src/lib/auth-signin.ts
+++ b/src/lib/auth-signin.ts
@@ -1,0 +1,48 @@
+// src/lib/auth-signin.ts
+'use client'
+
+import { signInWithPopup, signInWithRedirect } from 'firebase/auth'
+import { auth, provider } from '@/lib/firebase'
+
+/** iOS Safari and installed PWAs block auth popups, so prefer redirect there. */
+function prefersRedirect(): boolean {
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') return false
+  const ua = navigator.userAgent || ''
+  const isMobileUA = /iPhone|iPad|iPod|Android/i.test(ua)
+  const isStandalone =
+    window.matchMedia?.('(display-mode: standalone)')?.matches === true ||
+    // iOS Safari "Add to Home Screen"
+    (navigator as unknown as { standalone?: boolean }).standalone === true
+  return isMobileUA || isStandalone
+}
+
+/**
+ * Sign in with Google, robust across environments:
+ * - Mobile / installed PWA  → redirect (popups are unreliable / blocked there)
+ * - Desktop                 → popup, falling back to redirect if it's blocked
+ *
+ * On the redirect path the page navigates away to Google and back; the auth
+ * state is then picked up by the onAuthStateChanged listener in useAuth.
+ */
+export async function signInWithGoogle(): Promise<void> {
+  if (prefersRedirect()) {
+    await signInWithRedirect(auth, provider)
+    return
+  }
+
+  try {
+    await signInWithPopup(auth, provider)
+  } catch (err) {
+    const code = (err as { code?: string })?.code ?? ''
+    if (
+      code === 'auth/popup-blocked' ||
+      code === 'auth/popup-closed-by-user' ||
+      code === 'auth/cancelled-popup-request' ||
+      code === 'auth/operation-not-supported-in-this-environment'
+    ) {
+      await signInWithRedirect(auth, provider)
+      return
+    }
+    throw err
+  }
+}


### PR DESCRIPTION
## Problem
On iPhone (and installed PWAs), tapping **Continue with Google** did nothing — the button just spun. `signInWithPopup` is silently blocked by iOS Safari and standalone PWA mode, so the promise never resolves.

## Fix
- New `src/lib/auth-signin.ts` → `signInWithGoogle()`:
  - **Mobile / installed PWA** → `signInWithRedirect` (reliable where popups are blocked)
  - **Desktop** → `signInWithPopup`, falling back to `signInWithRedirect` if the popup is blocked/closed/unsupported
- `LoginButton` and `LoginPage` now call the shared helper.
- `LoginPage` routes **any** signed-in user onward (previously it only redirected when a `redirect`/`invite` query param was present — which would strand a user on `/login` after a mobile redirect returns with no params).

## ⚠️ Required config (not code)
For redirect sign-in to complete, the deploy domain must be allow-listed in **Firebase Console → Authentication → Settings → Authorized domains** (production domain + any Vercel preview/custom domains).

## Testing
`tsc --noEmit` clean, `npm run build` passes. Behavior verified at build level; the real check is a sign-in on an actual iPhone against the deployed domain (after the domain is authorized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_