### PR TITLE
feat(ux): bottom tab bar navigation (replaces swipe)

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,10 +1,9 @@
 // app/(main)/layout.tsx
 'use client'
 
-import React, { useRef, useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { ThemeProvider } from 'next-themes'
 import { usePathname, useRouter } from 'next/navigation'
-import { motion, useMotionValue, animate } from 'framer-motion'
 import { Bell, HomeIcon, PackageIcon, UsersIcon, SettingsIcon } from 'lucide-react'
 import { getAuth, onAuthStateChanged } from 'firebase/auth'
 import { getFirebaseMessaging } from '@/lib/firebase'
@@ -30,36 +29,12 @@ function isIOSWebKit() {
   const ua = navigator.userAgent
   return /iP(ad|hone|od)/i.test(ua) && /WebKit/i.test(ua)
 }
-function useViewportWidth() {
-  const [w, setW] = React.useState<number>(() => (typeof window !== 'undefined' ? window.innerWidth : 0))
-  React.useEffect(() => {
-    const onR = () => setW(window.innerWidth)
-    onR()
-    window.addEventListener('resize', onR)
-    return () => window.removeEventListener('resize', onR)
-  }, [])
-  return w
-}
 function safeRenderNode(node: React.ReactNode): React.ReactNode {
   if (node == null) return null
   if (typeof node === 'string' || typeof node === 'number') return node
-  if (Array.isArray(node)) return <>{node as any}</>
-  // @ts-ignore
-  if (React.isValidElement?.(node)) return node as any
+  if (Array.isArray(node)) return <>{node}</>
+  if (React.isValidElement(node)) return node
   return null
-}
-function detectModalOpen(): boolean {
-  if (typeof document === 'undefined') return false
-  return !!document.querySelector(
-    [
-      '[role="dialog"][data-state="open"]',
-      '[role="alertdialog"][data-state="open"]',
-      '[data-radix-portal] [role="dialog"][data-state="open"]',
-      '[data-radix-portal] [role="alertdialog"][data-state="open"]',
-      '[data-state="open"][data-side]',
-      '[data-radix-portal] [data-state="open"][data-side]',
-    ].join(', ')
-  )
 }
 
 /** ==== Route flash (one-time toast across navigation) ==== */
@@ -81,23 +56,7 @@ function RouteFlash() {
   return null
 }
 
-function shouldIgnoreTouch(target: EventTarget | null): boolean {
-  if (typeof document === 'undefined' || !target || !(target as Element).closest) return false
-  const el = target as Element
-  return !!el.closest([
-    '[data-no-swipe]',
-    'button',
-    '[role="button"]',
-    'a[href]',
-    'input',
-    'select',
-    'textarea',
-    '[contenteditable]',
-    '[data-radix-portal] *'
-  ].join(','))
-}
-
-/** ==== Standalone shell (no swipe nav) ==== */
+/** ==== Standalone shell (no tab bar) ==== */
 function StandaloneShell({ children }: { children: React.ReactNode }) {
   const router = useRouter()
   const softRefresh = async () => {
@@ -119,8 +78,8 @@ function StandaloneShell({ children }: { children: React.ReactNode }) {
   )
 }
 
-/** ==== Swipe shell (tabs + swipe + PTR per pane) ==== */
-function SwipeShell({
+/** ==== Tab shell (bottom tab bar, tap-only — no swipe) ==== */
+function TabShell({
   home, deliveries, family, notifications, settings,
 }: {
   home: React.ReactNode
@@ -131,42 +90,9 @@ function SwipeShell({
 }) {
   const router = useRouter()
   const pathname = usePathname()
-
-  useEffect(() => { try { initOutboxProcessor() } catch { } }, [])
-
-  // outbox toast/status listeners
-  useEffect(() => {
-    const onStart = (e: any) => { const c = e?.detail?.count ?? 0; if (c) toast(`Syncing ${c} change${c > 1 ? 's' : ''}…`) }
-    const onErr = (e: any) => { const msg = e?.detail?.error || 'Sync error'; toast.error(msg) }
-    const onDone = () => { toast.success('All offline changes synced') }
-    window.addEventListener('abot-sync-start', onStart as any)
-    window.addEventListener('abot-sync-error', onErr as any)
-    window.addEventListener('abot-sync-done', onDone as any)
-    return () => {
-      window.removeEventListener('abot-sync-start', onStart as any)
-      window.removeEventListener('abot-sync-error', onErr as any)
-      window.removeEventListener('abot-sync-done', onDone as any)
-    }
-  }, [])
-
   const auth = getAuth()
 
-  // Lock gestures when a modal/sheet is open
-  const [uiLocked, setUiLocked] = useState(false)
-  useEffect(() => {
-    const check = () => setUiLocked(detectModalOpen())
-    check()
-    const mo = new MutationObserver(check)
-    mo.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ['data-state', 'class', 'style'],
-    })
-    return () => mo.disconnect()
-  }, [])
-
-  // Push notifications (non-Safari)
+  // Push notifications (non-Safari) — register token once signed in.
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, (u) => {
       if (!u) return
@@ -196,7 +122,6 @@ function SwipeShell({
                 if (!j?.ok) console.warn('[push] save token failed', j)
               }).catch(err => console.warn('[push] save token error', err))
 
-              // Foreground messages -> toast
               onMessage(messaging, (payload) => {
                 const title = payload.notification?.title || 'Update'
                 const body = payload.notification?.body || ''
@@ -212,148 +137,22 @@ function SwipeShell({
 
   const nav = [
     { label: 'Home', href: '/', Icon: HomeIcon, node: home },
-    { label: 'MyDeliveries', href: '/deliveries', Icon: PackageIcon, node: deliveries },
+    { label: 'Deliveries', href: '/deliveries', Icon: PackageIcon, node: deliveries },
     { label: 'Family', href: '/family', Icon: UsersIcon, node: family },
-    { label: 'Notifications', href: '/notifications', Icon: Bell, node: notifications },
+    { label: 'Alerts', href: '/notifications', Icon: Bell, node: notifications },
     { label: 'Settings', href: '/settings', Icon: SettingsIcon, node: settings },
-
   ]
-
-  // Swipe constants (less sensitive)
-  const EDGE = 12
-  const STIFF = 420
-  const DAMP = 38
-  const VEL_TH = 1400
-  const DIST_TH = 0.35
-  const RUBBER = 0.22
-  const LOCK_AFTER = 14
-  const DIR_RATIO = 1.35
-
-  const width = useViewportWidth()
-  const x = useMotionValue(0)
 
   const index = (() => {
     const i = nav.findIndex(n => pathname === n.href || pathname.startsWith(n.href + '/'))
     return i === -1 ? 0 : i
   })()
 
+  // Prefetch all tabs for instant switching.
   useEffect(() => {
-    const edge = index === 0 ? -EDGE : index === nav.length - 1 ? EDGE : 0
-    animate(x, -index * width + edge, { type: 'spring', stiffness: STIFF, damping: DAMP })
-  }, [index, width, x])
-
-  // Prefetch neighbors & all tabs (best-effort)
-  useEffect(() => {
-    // @ts-ignore
-    const prefetch = (p?: string) => p && router.prefetch?.(p)
-    prefetch(nav[index - 1]?.href)
-    prefetch(nav[index + 1]?.href)
-  }, [index, router])
-  useEffect(() => {
-    // @ts-ignore
     nav.forEach(n => router.prefetch?.(n.href))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router])
-
-  // Gesture state
-  const modeRef = useRef<'idle' | 'detect' | 'horiz'>('idle')
-  const isDragging = useRef(false)
-  const startX = useRef<number>(0)
-  const startY = useRef<number>(0)
-  const lastX = useRef<number>(0)
-  const lastT = useRef<number>(0)
-  const velRef = useRef(0)
-  const baseRef = useRef(0)
-
-  function onTouchStart(e: React.TouchEvent) {
-    if (shouldIgnoreTouch(e.target)) {
-      modeRef.current = 'idle'
-      isDragging.current = false
-      return
-    }
-    if (uiLocked) return
-    modeRef.current = 'detect'
-    isDragging.current = false
-    startX.current = e.touches[0].clientX
-    startY.current = e.touches[0].clientY
-    lastX.current = startX.current
-    lastT.current = e.timeStamp
-    baseRef.current = x.get()
-    velRef.current = 0
-    // @ts-ignore
-    router.prefetch?.(nav[index - 1]?.href)
-    // @ts-ignore
-    router.prefetch?.(nav[index + 1]?.href)
-  }
-
-  function onTouchMove(e: React.TouchEvent) {
-    if (uiLocked) return
-    const cx = e.touches[0].clientX
-    const cy = e.touches[0].clientY
-    const dxAll = cx - startX.current
-    const dyAll = cy - startY.current
-
-    if (modeRef.current === 'detect') {
-      const traveled = Math.max(Math.abs(dxAll), Math.abs(dyAll))
-      if (traveled < LOCK_AFTER) return
-      if (Math.abs(dxAll) > Math.abs(dyAll) * DIR_RATIO) {
-        modeRef.current = 'horiz'
-        isDragging.current = true
-      } else {
-        modeRef.current = 'idle' // vertical: let PTR/scroll handle
-        return
-      }
-    }
-    if (!isDragging.current) return
-
-    const now = e.timeStamp
-    const dx = cx - lastX.current
-    const dt = Math.max(1, now - lastT.current)
-    const inst = (dx / dt) * 1000
-    velRef.current = velRef.current * 0.25 + inst * 0.75
-    lastX.current = cx
-    lastT.current = now
-
-    const desired = baseRef.current + dxAll
-    const max = 60
-    const min = -width * (nav.length - 1) - 60
-    let next = desired
-    if (next > max) next = max + (next - max) * RUBBER
-    if (next < min) next = min + (next - min) * RUBBER
-    x.set(next)
-  }
-
-  function onTouchEnd() {
-    if (uiLocked || !isDragging.current) return
-    isDragging.current = false
-    const offsetX = x.get()
-    const raw = -offsetX / width
-    const vel = velRef.current
-    const maxIndex = nav.length - 1
-    let ni = index
-
-    if (Math.abs(vel) > VEL_TH) {
-      if (vel < 0 && index < maxIndex) ni = index + 1
-      if (vel > 0 && index > 0) ni = index - 1
-    } else {
-      const dist = raw - index
-      if (Math.abs(dist) > DIST_TH) {
-        if (dist > 0 && index < maxIndex) ni = index + 1
-        else if (dist < 0 && index > 0) ni = index - 1
-      } else {
-        ni = Math.round(raw)
-      }
-    }
-    if (ni !== index) {
-      router.push(nav[ni].href, { scroll: false })
-      return
-    }
-    const edge = index === 0 ? -EDGE : index === nav.length - 1 ? EDGE : 0
-    animate(x, -index * width + edge, { type: 'spring', stiffness: STIFF, damping: DAMP })
-  }
-
-  // pane refs to drive PTR per pane
-  const paneRefs = React.useRef<Array<HTMLDivElement | null>>([])
-  const getPaneScrollEl = (i: number) => () => paneRefs.current[i] as Element | Document | null
 
   const softRefresh = async () => {
     try { router.refresh() } catch { }
@@ -361,63 +160,48 @@ function SwipeShell({
   }
 
   return (
-    <div className="flex flex-col min-h-screen overflow-hidden select-none bg-background text-foreground" style={{ height: '100vh' }}>
-      <nav className="fixed top-0 left-0 right-0 h-16 bg-background border-b flex items-center justify-around z-50">
-        {nav.map(({ label, href, Icon }, i) => (
-          <button
-            key={href}
-            type="button"
-            onClick={() => router.push(href, { scroll: false })}
-            className={`flex flex-col items-center text-xs p-2 ${i === index ? 'text-primary font-semibold' : 'text-muted-foreground'}`}
-            aria-current={i === index ? 'page' : undefined}
-          >
-            <Icon className="w-5 h-5 mb-1" />
-            {label}
-          </button>
-        ))}
-      </nav>
-
-      <motion.div
-        className="relative flex flex-row pt-16 overflow-hidden"
-        style={{
-          width: width * nav.length,
-          x,
-          height: 'calc(100vh - 4rem)',
-          touchAction: uiLocked ? 'auto' : 'pan-y',
-          WebkitOverflowScrolling: 'touch',
-        }}
-        onTouchStart={onTouchStart}
-        onTouchMove={onTouchMove}
-        onTouchEnd={onTouchEnd}
-        onTouchCancel={onTouchEnd}
+    <div className="flex flex-col bg-background text-foreground" style={{ height: '100dvh' }}>
+      {/* Active screen */}
+      <div
+        id="main-scroll"
+        className="flex-1 overflow-y-auto overscroll-contain"
+        style={{ paddingBottom: 'calc(4.25rem + env(safe-area-inset-bottom))' }}
       >
-        {[home, deliveries, family, notifications, settings].map((node, i) => (
-          <div
-            key={i}
-            ref={(el) => { paneRefs.current[i] = el }}
-            style={{
-              width,
-              flexShrink: 0,
-              height: '100%',
-              overflowY: 'auto',
-              overscrollBehaviorY: 'contain',
-              WebkitBackfaceVisibility: 'hidden',
-              backfaceVisibility: 'hidden',
-              transform: 'translateZ(0)',
-            }}
-          >
-            <PTR
-              getScrollEl={getPaneScrollEl(i)}
-              onRefresh={softRefresh}
-              className="min-h-full"
-              safetyTimeoutMs={2500}
-              minSpinMs={400}
+        <PTR
+          getScrollEl={() => document.getElementById('main-scroll')}
+          onRefresh={softRefresh}
+          className="min-h-full"
+          safetyTimeoutMs={2500}
+          minSpinMs={400}
+        >
+          {safeRenderNode(nav[index].node)}
+        </PTR>
+      </div>
+
+      {/* Bottom tab bar */}
+      <nav
+        className="fixed bottom-0 left-0 right-0 z-50 flex items-stretch justify-around border-t bg-background/95 backdrop-blur"
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+        aria-label="Primary"
+      >
+        {nav.map(({ label, href, Icon }, i) => {
+          const active = i === index
+          return (
+            <button
+              key={href}
+              type="button"
+              onClick={() => { if (i !== index) router.push(href, { scroll: false }) }}
+              aria-current={active ? 'page' : undefined}
+              className={`flex flex-1 flex-col items-center justify-center gap-0.5 min-h-[60px] px-1 transition-colors ${
+                active ? 'text-primary' : 'text-muted-foreground hover:text-foreground'
+              }`}
             >
-              {safeRenderNode(node)}
-            </PTR>
-          </div>
-        ))}
-      </motion.div>
+              <Icon className="h-5 w-5" strokeWidth={active ? 2.4 : 1.8} />
+              <span className={`text-[11px] leading-none ${active ? 'font-semibold' : ''}`}>{label}</span>
+            </button>
+          )
+        })}
+      </nav>
     </div>
   )
 }
@@ -440,7 +224,7 @@ export default function MainLayout({
 }) {
   const pathname = usePathname()
 
-  useFcm();
+  useFcm()
 
   useEffect(() => { try { initOutboxProcessor() } catch { } }, [])
 
@@ -470,7 +254,7 @@ export default function MainLayout({
         {isStandalone ? (
           <StandaloneShell>{children}</StandaloneShell>
         ) : (
-          <SwipeShell
+          <TabShell
             home={home ?? children}
             deliveries={deliveries}
             family={family}


### PR DESCRIPTION
First slice of the UX refinement pass — the navigation overhaul, which addresses the main "hard to control" complaint.

## What changed
- **Bottom tab bar, tap-only** — replaces the full-screen horizontal swipe across 5 tabs. That swipe fought with vertical scrolling and the Leaflet map and made accidental tab changes easy.
- **Tabs moved to the bottom** (thumb reach) with **60px tap targets**, clear active state, and **iOS safe-area** padding.
- **Only the active screen renders** now, instead of mounting all five simultaneously — lighter, and no 5× concurrent Firestore listeners.
- Tab labels: **"MyDeliveries" → "Deliveries"**, **"Notifications" → "Alerts"**.
- Removed the now-dead swipe gesture code, modal-lock MutationObserver, and a duplicated outbox listener set.

## Still to come in this UX pass (separate commits/PRs)
- Presence / Who's Home: simplify the button cluster + clearer manual-vs-auto.
- Deliveries: reduce density, streamline the add/edit form.
- Polish: tap targets, spacing, empty/loading/error states, replace `alert()` with toasts.

## Testing
`tsc --noEmit` clean, `npm run build` passes. Worth an eyeball on the preview — especially tab switching, scrolling, and the home-location map (no more accidental tab changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_