### PR TITLE
UX polish pass: presence, snappy buttons, toasts, deliveries

### DIFF
--- a/src/app/(main)/deliveries/page.tsx
+++ b/src/app/(main)/deliveries/page.tsx
@@ -13,7 +13,13 @@ import { useSelectedFamily } from '@/lib/selected-family'
 import { useAutoPresence } from '@/lib/useAutoPresence'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Plus, Loader2, MessageSquareText, Package, Search, PackageOpen } from 'lucide-react'
+import { Plus, Loader2, MessageSquareText, Package, Search, PackageOpen, MoreHorizontal, Pencil, Trash2 } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
 import DeliveryFormDialog from '@/app/components/DeliveryFormDialog'
 import DeliveryCard from '@/app/components/DeliveryCard'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -357,6 +363,40 @@ function DeliveriesPageContent({ familyId, families, myUid }: { familyId: string
 
   const keyFor = (d: any) => `${d.id}-${d.updatedAt?.seconds || d.createdAt?.seconds || ''}`
 
+  // Compact per-card actions: Notes stays inline; Edit/Delete move into an overflow menu.
+  const CardActions = ({ d, locked, openNotes }: { d: any; locked: boolean; openNotes: boolean }) => (
+    <div className="mt-2 flex items-center gap-2">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setNotesOpen((m) => ({ ...m, [d.id]: !m[d.id] }))}
+      >
+        <MessageSquareText className="h-4 w-4 mr-1" />
+        {openNotes ? 'Hide notes' : 'Notes'}
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" aria-label="More actions">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {!locked && (
+            <DropdownMenuItem onClick={() => { setEditingDelivery(d); setOpenForm(true) }}>
+              <Pencil className="h-4 w-4 mr-2" /> Edit
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => handleDelete(d.id)}
+          >
+            <Trash2 className="h-4 w-4 mr-2" /> Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+
   /* ---------------- Derived groups for current tab ---------------- */
   const sourceList = tab === 'upcoming' ? upcoming : archived
   const filtered = applyFilters(sourceList)
@@ -496,37 +536,7 @@ function DeliveriesPageContent({ familyId, families, myUid }: { familyId: string
                         <DeliveryCard familyId={familyId} {...props} />
 
                         {!selectionMode && (
-                          <div className="mt-2 flex flex-wrap gap-2">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() =>
-                                setNotesOpen((m) => ({ ...m, [d.id]: !m[d.id] }))
-                              }
-                            >
-                              <MessageSquareText className="h-4 w-4 mr-1" />
-                              {openNotes ? 'Hide Notes' : 'Notes'}
-                            </Button>
-                            {!locked && (
-                              <Button
-                                variant="secondary"
-                                size="sm"
-                                onClick={() => {
-                                  setEditingDelivery(d)
-                                  setOpenForm(true)
-                                }}
-                              >
-                                Edit
-                              </Button>
-                            )}
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              onClick={() => handleDelete(d.id)}
-                            >
-                              Delete
-                            </Button>
-                          </div>
+                          <CardActions d={d} locked={locked} openNotes={openNotes} />
                         )}
 
                         {openNotes && (
@@ -588,37 +598,7 @@ function DeliveriesPageContent({ familyId, families, myUid }: { familyId: string
                         <DeliveryCard familyId={familyId} {...props} />
 
                         {!selectionMode && (
-                          <div className="mt-2 flex flex-wrap gap-2">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() =>
-                                setNotesOpen((m) => ({ ...m, [d.id]: !m[d.id] }))
-                              }
-                            >
-                              <MessageSquareText className="h-4 w-4 mr-1" />
-                              {openNotes ? 'Hide Notes' : 'Notes'}
-                            </Button>
-                            {!locked && (
-                              <Button
-                                variant="secondary"
-                                size="sm"
-                                onClick={() => {
-                                  setEditingDelivery(d)
-                                  setOpenForm(true)
-                                }}
-                              >
-                                Edit
-                              </Button>
-                            )}
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              onClick={() => handleDelete(d.id)}
-                            >
-                              Delete
-                            </Button>
-                          </div>
+                          <CardActions d={d} locked={locked} openNotes={openNotes} />
                         )}
 
                         {openNotes && (

--- a/src/app/(main)/deliveries/page.tsx
+++ b/src/app/(main)/deliveries/page.tsx
@@ -13,7 +13,7 @@ import { useSelectedFamily } from '@/lib/selected-family'
 import { useAutoPresence } from '@/lib/useAutoPresence'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Plus, Loader2, MessageSquareText, Package } from 'lucide-react'
+import { Plus, Loader2, MessageSquareText, Package, Search, PackageOpen } from 'lucide-react'
 import DeliveryFormDialog from '@/app/components/DeliveryFormDialog'
 import DeliveryCard from '@/app/components/DeliveryCard'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -418,24 +418,26 @@ function DeliveriesPageContent({ familyId, families, myUid }: { familyId: string
         </div>
 
         {/* Search + status filter */}
-        <input
-          value={queryText}
-          onChange={(e) => setQueryText(e.target.value)}
-          placeholder="Search deliveries..."
-          className="border border-input bg-background text-foreground placeholder:text-muted-foreground px-3 py-1 rounded w-full sm:w-64"
-        />
+        <div className="relative w-full sm:w-64">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <input
+            value={queryText}
+            onChange={(e) => setQueryText(e.target.value)}
+            placeholder="Search deliveries…"
+            className="h-9 w-full rounded-md border border-input bg-background text-foreground placeholder:text-muted-foreground pl-8 pr-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          />
+        </div>
         <select
           value={filterStatus}
           onChange={(e) => setFilterStatus(e.target.value as any)}
-          className="border border-input bg-background text-foreground px-3 py-1 rounded text-sm"
+          className="h-9 rounded-md border border-input bg-background text-foreground px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
         >
-          <option value="all">All</option>
+          <option value="all">All statuses</option>
           <option value="pending">Pending</option>
           <option value="in_transit">In Transit</option>
           <option value="delivered">Delivered</option>
           <option value="cancelled">Cancelled</option>
         </select>
-        {/* ⬅️ removed Mine-only toggle */}
       </div>
 
       {/* Content */}
@@ -464,7 +466,10 @@ function DeliveriesPageContent({ familyId, families, myUid }: { familyId: string
             </div>
 
             {singles.length === 0 ? (
-              <p className="text-muted-foreground text-sm">No single deliveries</p>
+              <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-8 text-center">
+                <PackageOpen className="h-6 w-6 text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">No single deliveries {tab === 'archived' ? 'archived yet' : 'yet'}.</p>
+              </div>
             ) : (
               <div className="space-y-4">
                 {singles.map((d) => {
@@ -545,7 +550,10 @@ function DeliveriesPageContent({ familyId, families, myUid }: { familyId: string
             </div>
 
             {multiples.length === 0 ? (
-              <p className="text-muted-foreground text-sm">No multiple deliveries</p>
+              <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-8 text-center">
+                <PackageOpen className="h-6 w-6 text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">No multiple-item deliveries {tab === 'archived' ? 'archived yet' : 'yet'}.</p>
+              </div>
             ) : (
               <div className="space-y-4">
                 {multiples.map((d) => {

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -332,7 +332,10 @@ export default function HomePage() {
                   return (
                     <>
                       {homeBanner}
-                      <p className="text-muted-foreground text-sm">No members yet.</p>
+                      <div className="flex flex-col items-center justify-center gap-1 rounded-lg border border-dashed py-6 text-center">
+                        <p className="text-sm text-muted-foreground">No members yet.</p>
+                        <p className="text-xs text-muted-foreground">Invite family from the Family tab.</p>
+                      </div>
                     </>
                   )
                 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -28,7 +28,6 @@ import CreateFamilyModal from '../components/CreateFamilyModal'
 import JoinFamilyModal from '../components/JoinFamilyModal'
 import HomeDeliveriesToday from '../components/HomeDeliveriesToday'
 import Link from 'next/link'
-import { HelpCircleHint } from '../components/HelpCircleHint'
 import { useOnlineStatus } from '@/lib/hooks/useOnlinestatus'
 import { useSelectedFamily } from '@/lib/selected-family'
 
@@ -517,97 +516,87 @@ export default function HomePage() {
           </Link>
         )}
 
-        <div className="flex gap-4">
-          {(presenceLoading || loadingFamilies) ? (
-            <>
-              <Skeleton className="h-10 flex-1 rounded-md" />
-              <Skeleton className="h-10 flex-1 rounded-md" />
-            </>
-          ) : (
-            <div className="flex gap-4 w-full">
-              {myStatusSource === 'geo' ? (
-                <span className="flex-1">
-                  <Button type="button" variant={isHome ? 'default' : 'outline'} onClick={() => handlePresenceChange('home')} className="w-full" disabled>
-                    <HomeIcon className="w-4 h-4 mr-2" />
-                    I’m Home
-                  </Button>
-                </span>
-              ) : (
-                <Button type="button" variant={isHome ? 'default' : 'outline'} onClick={() => handlePresenceChange('home')} className="flex-1" disabled={presenceLoading || loadingFamilies}>
-                  <HomeIcon className="w-4 h-4 mr-2" />
-                  I’m Home
-                </Button>
-              )}
-
-              {myStatusSource === 'geo' ? (
-                <>
-                  <span className="flex-1">
-                    <Button type="button" variant={isHome === false ? 'default' : 'outline'} onClick={() => handlePresenceChange('away')} className="w-full" disabled>
-                      <DoorOpen className="w-4 h-4 mr-2" />
-                      I’m Out
-                    </Button>
-                  </span>
-                  <HelpCircleHint title="Auto-set status">
-                    <div className="space-y-2">
-                      <p>Your presence is updated automatically using your location.</p>
-                      <p>
-                        To change this, visit{' '}
-                        <Link href="/settings#default-family" className="text-blue-600 hover:underline">
-                          Settings →
-                        </Link>
-                      </p>
+        {/* Your status */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Your status</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {(presenceLoading || loadingFamilies) ? (
+              <Skeleton className="h-11 w-full rounded-md" />
+            ) : myStatusSource === 'geo' ? (
+              <>
+                <div className="flex items-center justify-between gap-3 rounded-lg border bg-muted/30 p-3">
+                  <div className="flex items-center gap-3">
+                    {isHome ? (
+                      <HomeIcon className="h-5 w-5 text-green-600" />
+                    ) : (
+                      <DoorOpen className="h-5 w-5 text-muted-foreground" />
+                    )}
+                    <div>
+                      <div className="font-medium">{isHome ? "You're home" : "You're out"}</div>
+                      <div className="text-xs text-muted-foreground">Set automatically from your location</div>
                     </div>
-                  </HelpCircleHint>
-                </>
-              ) : (
-                <Button type="button" variant={isHome === false ? 'default' : 'outline'} onClick={() => handlePresenceChange('away')} className="flex-1">
-                  <DoorOpen className="w-4 h-4 mr-2" />
-                  I’m Out
+                  </div>
+                  <span className="text-[11px] px-2 py-0.5 rounded-full border bg-background text-muted-foreground">Auto</span>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Prefer to set it yourself? Turn off auto-presence in{' '}
+                  <Link href="/settings#default-family" className="underline">Settings</Link>.
+                </p>
+              </>
+            ) : (
+              <div className="grid grid-cols-2 gap-2">
+                <Button type="button" variant={isHome ? 'default' : 'outline'} onClick={() => handlePresenceChange('home')} className="h-11">
+                  <HomeIcon className="w-4 h-4 mr-2" /> I’m Home
                 </Button>
-              )}
-            </div>
-          )}
-        </div>
+                <Button type="button" variant={isHome === false ? 'default' : 'outline'} onClick={() => handlePresenceChange('away')} className="h-11">
+                  <DoorOpen className="w-4 h-4 mr-2" /> I’m Out
+                </Button>
+              </div>
+            )}
 
-        {/* On my way home broadcast */}
-        {!presenceLoading && !loadingFamilies && familyId && (
-          myPresence?.enRoute ? (
-            <div className="rounded-lg border p-3 bg-sky-50/60 dark:bg-sky-950/20 flex items-center justify-between gap-3">
-              <div className="flex items-center gap-2 text-sm min-w-0">
-                <Truck className="w-4 h-4 text-sky-600 shrink-0" />
-                <span className="font-medium">You&apos;re on the way home</span>
-                {myPresence.etaMinutes != null && (
-                  <span className="text-muted-foreground truncate">• ETA ~{myPresence.etaMinutes} min</span>
-                )}
-              </div>
-              <Button type="button" variant="ghost" size="sm" onClick={handleClearEnRoute} className="shrink-0">
-                <X className="w-4 h-4 mr-1" /> Cancel
-              </Button>
-            </div>
-          ) : isHome ? null : (
-            <div className="rounded-lg border p-3 bg-muted/20 flex flex-col sm:flex-row sm:items-center gap-2">
-              <div className="flex items-center gap-2 text-sm flex-1 min-w-0">
-                <Truck className="w-4 h-4 text-muted-foreground shrink-0" />
-                <span className="text-muted-foreground truncate">Let your family know you&apos;re heading home</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <select
-                  value={etaChoice ?? ''}
-                  onChange={(e) => setEtaChoice(e.target.value === '' ? null : Number(e.target.value))}
-                  className="border border-input bg-background text-foreground px-2 py-1 rounded text-sm"
-                  aria-label="Estimated time to arrival"
-                >
-                  {ETA_OPTIONS.map((o) => (
-                    <option key={o.label} value={o.minutes ?? ''}>{o.label}</option>
-                  ))}
-                </select>
-                <Button type="button" onClick={handleSetEnRoute}>
-                  <Truck className="w-4 h-4 mr-2" /> On my way home
-                </Button>
-              </div>
-            </div>
-          )
-        )}
+            {/* On my way home — secondary action, only when not currently home */}
+            {!presenceLoading && !loadingFamilies && familyId && !isHome && (
+              myPresence?.enRoute ? (
+                <div className="flex items-center justify-between gap-3 rounded-lg border bg-sky-50/60 dark:bg-sky-950/20 p-3">
+                  <div className="flex items-center gap-2 text-sm min-w-0">
+                    <Truck className="w-4 h-4 text-sky-600 shrink-0" />
+                    <span className="font-medium">On the way home</span>
+                    {myPresence.etaMinutes != null && (
+                      <span className="text-muted-foreground truncate">• ~{myPresence.etaMinutes} min</span>
+                    )}
+                  </div>
+                  <Button type="button" variant="ghost" size="sm" onClick={handleClearEnRoute} className="shrink-0">
+                    <X className="w-4 h-4 mr-1" /> Cancel
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex flex-col sm:flex-row sm:items-center gap-2 pt-1">
+                  <div className="flex items-center gap-2 text-sm flex-1 min-w-0 text-muted-foreground">
+                    <Truck className="w-4 h-4 shrink-0" />
+                    <span className="truncate">Heading home? Let your family know.</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <select
+                      value={etaChoice ?? ''}
+                      onChange={(e) => setEtaChoice(e.target.value === '' ? null : Number(e.target.value))}
+                      className="h-9 border border-input bg-background text-foreground px-2 rounded-md text-sm"
+                      aria-label="Estimated time to arrival"
+                    >
+                      {ETA_OPTIONS.map((o) => (
+                        <option key={o.label} value={o.minutes ?? ''}>{o.label}</option>
+                      ))}
+                    </select>
+                    <Button type="button" onClick={handleSetEnRoute} className="h-9">
+                      <Truck className="w-4 h-4 mr-2" /> On my way
+                    </Button>
+                  </div>
+                </div>
+              )
+            )}
+          </CardContent>
+        </Card>
       </main>
     </>
   )

--- a/src/app/components/DeliveryCard.tsx
+++ b/src/app/components/DeliveryCard.tsx
@@ -224,7 +224,7 @@ export default function DeliveryCard({ familyId, order, delivery, onDelete }: Pr
     setProcessing(true)
     try {
       const res = await markChildItemAsReceived(familyId, parentCollection, parent.id, itemId)
-      if (!res || res.success === false) alert(res?.message ?? 'Failed')
+      if (!res || res.success === false) toast.error(res?.message ?? 'Failed to mark item received')
     } finally {
       setProcessing(false)
     }
@@ -255,7 +255,7 @@ export default function DeliveryCard({ familyId, order, delivery, onDelete }: Pr
           })
         } else {
           const res = await markDeliveryAsReceived(familyId, parent.id, '')
-          if (!res || res.success === false) { alert(res?.message ?? 'Failed'); setProcessing(false); setConfirmOpen(false); return }
+          if (!res || res.success === false) { toast.error(res?.message ?? 'Failed to mark delivered'); setProcessing(false); setConfirmOpen(false); return }
           await updateDoc(ref, {
             archived: true,
             archivedAt: new Date(),
@@ -264,7 +264,7 @@ export default function DeliveryCard({ familyId, order, delivery, onDelete }: Pr
         }
       }
     } catch {
-      alert('Failed to mark as delivered')
+      toast.error('Failed to mark as delivered')
     } finally {
       setProcessing(false)
       setConfirmOpen(false)

--- a/src/app/components/DeliveryFormDialog.tsx
+++ b/src/app/components/DeliveryFormDialog.tsx
@@ -503,7 +503,7 @@ export default function DeliveryFormDialog({ open, onOpenChange, familyId, deliv
       }
     } catch (err) {
       console.error('DeliveryFormDialog submit err', err)
-      alert('Failed to save delivery')
+      toast.error('Failed to save delivery')
     } finally {
       setIsSaving(false)
     }

--- a/src/app/components/DeliveryFormDialog.tsx
+++ b/src/app/components/DeliveryFormDialog.tsx
@@ -554,7 +554,7 @@ export default function DeliveryFormDialog({ open, onOpenChange, familyId, deliv
               <Label>Expected date &amp; time</Label>
               <input
                 type="datetime-local"
-                className="mt-1 block w-full rounded border px-2 py-1"
+                className="mt-1 block h-9 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                 value={values.expectedDate}
                 onChange={(e) => setValues((v) => ({ ...v, expectedDate: e.target.value }))}
               />

--- a/src/app/components/HomeDeliveriesToday.tsx
+++ b/src/app/components/HomeDeliveriesToday.tsx
@@ -24,6 +24,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Textarea } from '@/components/ui/textarea'
+import { toast } from 'sonner'
 import { MarkDeliveryButton } from './MarkDeliveryButton'
 import { MarkDeliveryItemButton } from './MarkDeliveryItemButton'
 import { ReceiverNoteDialog } from './ReceiverNoteDialog'
@@ -260,7 +261,7 @@ function DeliveryNotesThreadInline({ familyId, deliveryId }: { familyId: string;
       setText('')
     } catch (e) {
       console.error('Failed to add note', e)
-      alert('Failed to add note')
+      toast.error('Failed to add note')
     } finally {
       setAdding(false)
     }
@@ -518,7 +519,7 @@ export default function HomeDeliveriesToday({
         })
       }
     } catch (err) {
-      console.error('handleMarkDelivery', err); alert('Failed to mark delivery')
+      console.error('handleMarkDelivery', err); toast.error('Failed to mark delivery')
     } finally {
       setProcessingId(null); setDialogOpenId(null)
     }
@@ -529,9 +530,9 @@ export default function HomeDeliveriesToday({
     setProcessingId(itemId)
     try {
       const res = await markChildItemAsReceived(familyId, 'deliveries', deliveryId, itemId)
-      if (!res || res.success === false) alert(res?.message ?? 'Failed to mark item')
+      if (!res || res.success === false) toast.error(res?.message ?? 'Failed to mark item')
     } catch (err) {
-      console.error('handleMarkDeliveryItem', err); alert('Failed to mark item')
+      console.error('handleMarkDeliveryItem', err); toast.error('Failed to mark item')
     } finally {
       setProcessingId(null)
     }

--- a/src/app/components/PresenceSettings.tsx
+++ b/src/app/components/PresenceSettings.tsx
@@ -173,7 +173,9 @@ export default function PresenceSettings({ familyId: propFamilyId }: { familyId?
               if (/Android/i.test(navigator.userAgent)) {
                 window.open('intent://settings#Intent;scheme=android.settings.LOCATION_SOURCE_SETTINGS;end')
               } else {
-                alert('To enable location on iOS:\n\n1) Open Settings\n2) Scroll to Safari (or your browser)\n3) Tap Location\n4) Set to “While Using the App”.')
+                toast.message('Enable location on iOS', {
+                  description: 'Settings → Safari (or your browser) → Location → set to “While Using the App”.',
+                })
               }
             }
           }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium select-none cursor-pointer transition-all duration-150 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {


### PR DESCRIPTION
A batch of UX refinements to make the app feel more professional and snappy (continuing after the bottom-tab nav in #18).

## Changes
**Presence / Who's Home**
- One cohesive **"Your status"** card. Manual = clean Home/Out pair (44px targets); Auto = explicit read-only state with an **"Auto"** pill + Settings link (no more greyed-out buttons that looked broken). "On my way" is a secondary action shown only when you're out.

**Snappy, app-wide**
- Buttons get tactile **`active:scale` press feedback**, pointer cursor, 150ms transition.
- Every blocking native **`alert()` replaced with non-blocking toasts**.

**Deliveries**
- Search field with a **search icon**, consistent `h-9` styling + focus ring; restyled status filter.
- Each card's **Notes / Edit / Delete** row collapsed into a compact **overflow menu** (Notes stays inline; Edit/Delete behind `⋯` so destructive delete isn't a stray tap).
- Friendly **empty states** everywhere (deliveries + "Who's Home"), context-aware for Upcoming vs Archived.

**Forms**
- Brought the expected-date input in line with the new control styling.

## UX pass progress
- ✅ #1 Navigation — merged (#18)
- ✅ #2 Presence
- ✅ #3 Deliveries (controls, empty states, decluttered cards)
- ✅ #4 Polish (snappy buttons, toasts, consistent inputs)

## Testing
`tsc --noEmit` clean, `npm run build` passes throughout. Worth an eyeball on the preview for the overall feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)