### PR TITLE
feat: notification controls + notify-when-home

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -53,6 +53,41 @@ function chunk<T>(arr: T[], size: number): T[][] {
 }
 
 /* =============================================================================
+   Notification preferences (per-user): quiet hours + per-type toggles
+   Stored at users/{uid}.notificationPrefs
+   ============================================================================= */
+type NotifType = 'delivery' | 'presence' | 'enroute'
+
+/** Current minute-of-day in Asia/Manila (UTC+8). */
+function nowManilaMinutes(): number {
+  const z = new Date(Date.now() + 8 * 3600_000)
+  return z.getUTCHours() * 60 + z.getUTCMinutes()
+}
+function parseHM(s: any): number | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(typeof s === 'string' ? s : '')
+  if (!m) return null
+  const v = Number(m[1]) * 60 + Number(m[2])
+  return v >= 0 && v < 1440 ? v : null
+}
+/** Is "now" inside the user's quiet-hours window (supports overnight ranges)? */
+function isQuietNow(prefs: any): boolean {
+  if (!prefs?.quietHoursEnabled) return false
+  const start = parseHM(prefs.quietHoursStart)
+  const end = parseHM(prefs.quietHoursEnd)
+  if (start == null || end == null || start === end) return false
+  const now = nowManilaMinutes()
+  return start < end ? now >= start && now < end : now >= start || now < end
+}
+/** Whether a notification type should reach this user per their toggles.
+ *  mode 'forceWhenDisabled' inverts it (used for explicit opt-ins like watch-home). */
+function userAcceptsType(prefs: any, type: NotifType | undefined, mode: 'normal' | 'forceWhenDisabled'): boolean {
+  if (!type) return true
+  const enabled = prefs?.[type] !== false // default ON
+  return mode === 'forceWhenDisabled' ? !enabled : enabled
+}
+
+
+/* =============================================================================
    Idempotency helpers
    ============================================================================= */
 async function markDailyNotifiedIfNeeded(familyId: string, dateKey: string): Promise<boolean> {
@@ -131,29 +166,29 @@ async function recordEvent(
 /* =============================================================================
    Unified notifier for a family's members (multicast + Safari fallback)
    ============================================================================= */
-async function sendNotificationToFamilyMembers(
+async function sendNotificationToUids(
+  uids: string[],
   familyId: string,
   title: string,
   body: string,
   extraData: Record<string, string> = {},
-  opts?: { excludeUids?: string[] }
+  opts?: { type?: NotifType; mode?: 'normal' | 'forceWhenDisabled' }
 ): Promise<void> {
   try {
-    const exclude = new Set(opts?.excludeUids ?? [])
+    const mode = opts?.mode ?? 'normal'
 
-    // Members
-    const membersSnap = await firestore.collection('families').doc(familyId).collection('members').get()
-    const memberUids = membersSnap.docs.map((d) => d.id).filter((uid) => !exclude.has(uid))
-    logger.info('sendNotificationToFamilyMembers: members fetched', { familyId, memberCount: memberUids.length })
-
-    // Gather tokens
+    // Gather tokens — honouring each user's per-type prefs + quiet hours.
     const userTokens: Array<{ uid: string; token: string }> = []
     const safariFallbackUids: string[] = []
-    for (const uid of memberUids) {
+    for (const uid of uids) {
       const userDoc = await firestore.collection('users').doc(uid).get()
       const u = userDoc.data() as any
+      const prefs = u?.notificationPrefs ?? {}
+
+      if (!userAcceptsType(prefs, opts?.type, mode)) continue
+      if (isQuietNow(prefs)) continue
+
       const tCount = Array.isArray(u?.fcmTokens) ? u.fcmTokens.length : 0
-      logger.info('member token presence', { familyId, uid, tokenCount: tCount, safariFallback: !!u?.isSafari })
       if (tCount > 0) {
         for (const t of u!.fcmTokens as string[]) userTokens.push({ uid, token: t })
       } else if (u?.isSafari) {
@@ -164,9 +199,11 @@ async function sendNotificationToFamilyMembers(
     const tokens = Array.from(new Set(userTokens.map(x => x.token))) // dedupe
     logger.info('push token summary', {
       familyId,
-      memberCount: memberUids.length,
+      recipients: uids.length,
       distinctTokenCount: tokens.length,
       safariFallbackCount: safariFallbackUids.length,
+      type: opts?.type ?? null,
+      mode,
     })
 
     const tag = String(extraData.tag ?? `abot:${familyId}`)
@@ -175,16 +212,11 @@ async function sendNotificationToFamilyMembers(
     // Multicast in chunks — DATA-ONLY payloads
     if (tokens.length > 0) {
       const chunks = chunk(tokens, 500)
-      logger.info('multicast chunks', { familyId, chunks: chunks.length })
       for (const part of chunks) {
         try {
           const res = await messaging.sendEachForMulticast({
             tokens: part,
-            // No "notification" key here → data-only
-            webpush: {
-              headers: { TTL: '1800' },
-              // fcmOptions.link is optional in data-only; we still set url in data and handle in SW
-            },
+            webpush: { headers: { TTL: '1800' } },
             data: {
               familyId,
               ...extraData,
@@ -211,7 +243,6 @@ async function sendNotificationToFamilyMembers(
               const code = (r.error as any)?.code || ''
               if (code.includes('registration-token-not-registered') || code.includes('invalid-registration-token')) {
                 const owners = userTokens.filter(ut => ut.token === token).map(ut => ut.uid)
-                logger.warn('pruning invalid token', { familyId, ownersCount: owners.length })
                 owners.forEach(uid => {
                   removals.push(
                     firestore.collection('users').doc(uid).update({
@@ -241,11 +272,30 @@ async function sendNotificationToFamilyMembers(
             title, body, familyId, ...extraData, tag, url, timestamp: Date.now(),
           }),
         })
-        logger.info('queued safari fallback', { familyId, uid })
       } catch (err) {
         logger.error('safari fallback queue failed', { familyId, uid, error: err instanceof Error ? err.message : JSON.stringify(err) })
       }
     }
+  } catch (err) {
+    logger.error('sendNotificationToUids error', {
+      familyId,
+      error: err instanceof Error ? err.message : JSON.stringify(err),
+    })
+  }
+}
+
+async function sendNotificationToFamilyMembers(
+  familyId: string,
+  title: string,
+  body: string,
+  extraData: Record<string, string> = {},
+  opts?: { excludeUids?: string[]; type?: NotifType }
+): Promise<void> {
+  try {
+    const exclude = new Set(opts?.excludeUids ?? [])
+    const membersSnap = await firestore.collection('families').doc(familyId).collection('members').get()
+    const memberUids = membersSnap.docs.map((d) => d.id).filter((uid) => !exclude.has(uid))
+    await sendNotificationToUids(memberUids, familyId, title, body, extraData, { type: opts?.type })
   } catch (err) {
     logger.error('sendNotificationToFamilyMembers error', {
       familyId,
@@ -275,7 +325,8 @@ async function sendDeliveryNotificationForFamily(
     familyId,
     'Delivery is on its way!',
     'Delivery expected today is now in transit.',
-    extra
+    extra,
+    { type: 'delivery' }
   )
 }
 
@@ -389,7 +440,8 @@ export const scheduledDailyDeliveryNotification = scheduler.onSchedule(
           familyId,
           'Today’s deliveries',
           'You have deliveries scheduled for today.',
-          { tag: `today:${familyId}`, url: '/deliveries' }
+          { tag: `today:${familyId}`, url: '/deliveries' },
+          { type: 'delivery' }
         )
 
         visited.add(familyId)
@@ -446,7 +498,7 @@ export const notifyDeliveryCreatedToday = onDocumentCreated(
         'New delivery for today',
         'A delivery scheduled for today was added.',
         { deliveryId, tag: `today:${familyId}`, url: '/deliveries' },
-        actor ? { excludeUids: [actor] } : undefined
+        { type: 'delivery', ...(actor ? { excludeUids: [actor] } : {}) }
       )
     }
   }
@@ -512,8 +564,32 @@ export const notifyPresenceStatusChange = onDocumentWritten(
       title,
       body,
       { changedUserId: userId, status: nextStatus, tag: `presence:${familyId}:${userId}`, url: '/family' },
-      { excludeUids: [userId] }
+      { excludeUids: [userId], type: 'presence' }
     );
+
+    // "Notify me when ___ gets home": members who explicitly watch this user
+    // still get an arrival alert even if they muted general presence pushes.
+    if (nextStatus === 'home') {
+      try {
+        const watchSnap = await firestore
+          .collection('families').doc(familyId).collection('members')
+          .where(`watchHome.${userId}`, '==', true)
+          .get();
+        const watchers = watchSnap.docs.map((d) => d.id).filter((uid) => uid !== userId);
+        if (watchers.length) {
+          await sendNotificationToUids(
+            watchers,
+            familyId,
+            `🏠 ${displayName} is home`,
+            `${displayName} just arrived home.`,
+            { changedUserId: userId, status: 'home', tag: `watchhome:${familyId}:${userId}`, url: '/family' },
+            { type: 'presence', mode: 'forceWhenDisabled' }
+          );
+        }
+      } catch (e) {
+        logger.error('watch-home notify failed', { familyId, userId, error: e instanceof Error ? e.message : String(e) });
+      }
+    }
   }
 );
 
@@ -566,7 +642,7 @@ export const notifyEnRoute = onDocumentWritten(
       title,
       body,
       { changedUserId: userId, tag: `enroute:${familyId}:${userId}`, url: '/' },
-      { excludeUids: [userId] }
+      { excludeUids: [userId], type: 'enroute' }
     );
   }
 );

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -11,9 +11,10 @@ import {
   onSnapshot,
   serverTimestamp,
   setDoc,
+  deleteField,
 } from 'firebase/firestore'
 import { firestore } from '@/lib/firebase'
-import { Loader2, Home as HomeIcon, DoorOpen, MapPin, ShoppingCart, Truck, X } from 'lucide-react'
+import { Loader2, Home as HomeIcon, DoorOpen, MapPin, ShoppingCart, Truck, X, Bell, BellRing } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useAutoPresence } from '@/lib/useAutoPresence'
 import {
@@ -169,6 +170,22 @@ export default function HomePage() {
     return () => unsub()
   }, [user?.uid, familyId, justChangedStatusAt, userAutoPresence, hydrationKey])
 
+  const toggleWatch = async (targetUid: string) => {
+    if (!user?.uid || !familyId || targetUid === user.uid) return
+    const mine = membersLive.find((mm) => mm.uid === user.uid)?.watchHome as Record<string, boolean> | undefined
+    const isWatching = !!mine?.[targetUid]
+    try {
+      await setDoc(
+        doc(firestore, 'families', familyId, 'members', user.uid),
+        { watchHome: { [targetUid]: isWatching ? deleteField() : true } },
+        { merge: true }
+      )
+      toast.success(isWatching ? 'Stopped watching' : 'You’ll be notified when they get home')
+    } catch {
+      toast.error('Could not update')
+    }
+  }
+
   const handlePresenceChange = async (newStatus: 'home' | 'away') => {
     if (!user || !familyId) return
     const ref = doc(firestore, 'families', familyId, 'members', user.uid)
@@ -315,6 +332,10 @@ export default function HomePage() {
                   })
                 )
 
+                const myWatch = (membersLive.find((mm) => mm.uid === user?.uid)?.watchHome ?? {}) as Record<string, boolean>
+                const homeCount = members.filter((m) => presenceMap.get(m.uid)?.status === 'home').length
+                const outCount = members.filter((m) => presenceMap.get(m.uid)?.status === 'away').length
+
                 if (loading) {
                   return (
                     <>
@@ -354,6 +375,15 @@ export default function HomePage() {
                     <div className="space-y-2">
                       {homeBanner}
 
+                      <div className="flex items-center gap-3 px-2 text-xs text-muted-foreground">
+                        <span className="inline-flex items-center gap-1">
+                          <HomeIcon className="h-3.5 w-3.5 text-green-600" /> {homeCount} home
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <DoorOpen className="h-3.5 w-3.5" /> {outCount} out
+                        </span>
+                      </div>
+
                       <div className="space-y-2">
                         <AnimatePresence>
                           {members.map((m) => {
@@ -367,6 +397,7 @@ export default function HomePage() {
                               .toUpperCase()
 
                             const isCurrentUser = m.uid === user?.uid
+                            const watchingMember = !!myWatch[m.uid as string]
 
                             return (
                               <motion.div
@@ -423,6 +454,17 @@ export default function HomePage() {
                                 </div>
 
                                 <div className="flex items-center gap-2">
+                                  {!isCurrentUser && (
+                                    <button
+                                      type="button"
+                                      onClick={() => toggleWatch(m.uid as string)}
+                                      aria-label={watchingMember ? `Stop home alerts for ${presence.name}` : `Notify me when ${presence.name} gets home`}
+                                      title={watchingMember ? 'Watching — you’ll be alerted when they get home' : 'Notify me when they get home'}
+                                      className={`rounded-md p-1.5 transition-colors active:scale-95 ${watchingMember ? 'text-primary' : 'text-muted-foreground hover:text-foreground'}`}
+                                    >
+                                      {watchingMember ? <BellRing className="h-4 w-4" /> : <Bell className="h-4 w-4" />}
+                                    </button>
+                                  )}
                                   <Tooltip>
                                     <TooltipTrigger asChild>
                                       <span className="text-[10px] px-2 py-0.5 rounded bg-muted text-muted-foreground border border-muted-foreground/10 cursor-default">

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -28,6 +28,7 @@ import { useTheme } from 'next-themes';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import DefaultFamilySelector from '@/app/components/DefaultFamilySelector';
+import NotificationPreferences from '@/app/components/NotificationPreferences';
 import { Skeleton } from '@/components/ui/skeleton';
 
 // ⬇️ Dynamic client-only import fixes "editor not showing" issues in some builds.
@@ -231,6 +232,10 @@ export default function SettingsPage() {
                 Notifications are blocked in your browser. Allow them in site settings and try again.
               </p>
             )}
+
+            <Separator />
+            <p className="text-xs font-medium text-muted-foreground">What to notify me about</p>
+            <NotificationPreferences />
           </CardContent>
         </Card>
 

--- a/src/app/components/NotificationPreferences.tsx
+++ b/src/app/components/NotificationPreferences.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { doc, onSnapshot, setDoc } from 'firebase/firestore'
+import { firestore } from '@/lib/firebase'
+import { useAuth } from '@/lib/useAuth'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+import { Skeleton } from '@/components/ui/skeleton'
+import { toast } from 'sonner'
+
+type Prefs = {
+  delivery: boolean
+  presence: boolean
+  enroute: boolean
+  quietHoursEnabled: boolean
+  quietHoursStart: string
+  quietHoursEnd: string
+}
+
+const DEFAULTS: Prefs = {
+  delivery: true,
+  presence: true,
+  enroute: true,
+  quietHoursEnabled: false,
+  quietHoursStart: '22:00',
+  quietHoursEnd: '07:00',
+}
+
+const TYPE_ROWS: { key: 'delivery' | 'presence' | 'enroute'; label: string; desc: string }[] = [
+  { key: 'delivery', label: 'Deliveries', desc: 'New, in-transit, and daily delivery alerts.' },
+  { key: 'presence', label: 'Home & away', desc: 'When a family member arrives or leaves home.' },
+  { key: 'enroute', label: 'On my way', desc: 'When someone broadcasts they’re heading home.' },
+]
+
+export default function NotificationPreferences() {
+  const { user } = useAuth()
+  const [prefs, setPrefs] = useState<Prefs>(DEFAULTS)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    if (!user?.uid) return
+    const ref = doc(firestore, 'users', user.uid)
+    const unsub = onSnapshot(
+      ref,
+      (snap) => {
+        const p = (snap.data()?.notificationPrefs ?? {}) as Partial<Prefs>
+        setPrefs({ ...DEFAULTS, ...p })
+        setLoaded(true)
+      },
+      () => setLoaded(true)
+    )
+    return () => unsub()
+  }, [user?.uid])
+
+  const save = async (patch: Partial<Prefs>) => {
+    if (!user?.uid) return
+    const next = { ...prefs, ...patch }
+    setPrefs(next) // optimistic
+    try {
+      await setDoc(doc(firestore, 'users', user.uid), { notificationPrefs: next }, { merge: true })
+    } catch {
+      toast.error('Could not save preference')
+    }
+  }
+
+  if (!loaded) {
+    return <Skeleton className="h-24 w-full rounded-md" />
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-3">
+        {TYPE_ROWS.map((row) => (
+          <div key={row.key} className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <Label className="text-sm font-medium">{row.label}</Label>
+              <p className="text-xs text-muted-foreground">{row.desc}</p>
+            </div>
+            <Switch
+              checked={prefs[row.key]}
+              onCheckedChange={(v) => save({ [row.key]: v })}
+              aria-label={`Toggle ${row.label} notifications`}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-md border p-3 space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <Label className="text-sm font-medium">Quiet hours</Label>
+            <p className="text-xs text-muted-foreground">Silence pushes overnight (your local time).</p>
+          </div>
+          <Switch
+            checked={prefs.quietHoursEnabled}
+            onCheckedChange={(v) => save({ quietHoursEnabled: v })}
+            aria-label="Toggle quiet hours"
+          />
+        </div>
+        {prefs.quietHoursEnabled && (
+          <div className="flex items-center gap-3 text-sm">
+            <label className="flex items-center gap-2">
+              <span className="text-muted-foreground">From</span>
+              <input
+                type="time"
+                value={prefs.quietHoursStart}
+                onChange={(e) => save({ quietHoursStart: e.target.value })}
+                className="h-9 rounded-md border border-input bg-background px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              />
+            </label>
+            <label className="flex items-center gap-2">
+              <span className="text-muted-foreground">to</span>
+              <input
+                type="time"
+                value={prefs.quietHoursEnd}
+                onChange={(e) => save({ quietHoursEnd: e.target.value })}
+                className="h-9 rounded-md border border-input bg-background px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              />
+            </label>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
The first chunk of the feature roadmap, in one PR as requested: notification controls + "notify me when someone gets home."

## Notification preferences (quiet hours + per-type)
- New per-user prefs at `users/{uid}.notificationPrefs`:
  - **Per-type toggles:** Deliveries · Home & away · On my way.
  - **Quiet hours:** enable + from/to time (overnight-aware, Asia/Manila).
- **Settings → Notifications** gets a "What to notify me about" section to manage these.
- **Cloud Functions** now filter *every* push per recipient: the central notifier (refactored into `sendNotificationToUids`) skips users who muted that type or are inside their quiet hours. Each trigger tags its type (`delivery` / `presence` / `enroute`).

## "Notify me when ___ gets home"
- A **bell toggle** on each family member in the Home → Who's Home card. It writes `watchHome` on *your own* member doc (rules already allow this).
- When a watched member arrives home, the watcher gets a dedicated **🏠 alert even if they've muted general presence pushes** (quiet hours still respected, no duplicate for those who keep presence on).

## Bonus
- A compact **"N home · M out"** glance at the top of Who's Home.

## ⚠️ Deploy note
The push-filtering and watch-home alerts live in **Cloud Functions** — they only take effect after you run **`firebase deploy --only functions`**. The preferences UI and watch toggles persist to Firestore immediately regardless.

No Firestore rules/index changes needed (writes target the owner's own user/member docs; the watch query uses an auto-indexed map field).

## Testing
Client `tsc --noEmit` + `npm run build` pass; functions `tsc` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_