### PR TITLE
ci: manual Firebase deploy workflow (mobile-friendly)

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,0 +1,55 @@
+name: Firebase Deploy
+
+# Manual trigger only — tap "Run workflow" from the Actions tab (works on mobile
+# via the GitHub web UI). Nothing deploys automatically on push.
+on:
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: 'What to deploy'
+        type: choice
+        default: 'functions,firestore:rules,firestore:indexes'
+        options:
+          - 'functions,firestore:rules,firestore:indexes'
+          - 'functions'
+          - 'firestore:rules,firestore:indexes'
+          - 'firestore:rules'
+          - 'firestore:indexes'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Install functions dependencies
+        # Needed so the firebase.json predeploy hook (npm run build) can run.
+        run: npm ci --prefix functions
+
+      - name: Write service account credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT" ]; then
+            echo "::error::Missing FIREBASE_SERVICE_ACCOUNT secret. Add it in repo Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/gcp-key.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/gcp-key.json" >> "$GITHUB_ENV"
+
+      - name: Deploy
+        run: |
+          firebase deploy \
+            --only "${{ github.event.inputs.targets }}" \
+            --project abot-ko-na \
+            --non-interactive \
+            --force


### PR DESCRIPTION
Adds a manual **Firebase Deploy** GitHub Action so deploys can be triggered from anywhere — including mobile — via the Actions tab, no terminal needed.

- **Trigger:** `workflow_dispatch` only (a "Run workflow" button). Nothing deploys automatically on push.
- **Targets:** pick from a dropdown — defaults to `functions,firestore:rules,firestore:indexes`.
- **Auth:** uses a `FIREBASE_SERVICE_ACCOUNT` repo secret (service-account JSON). The job fails fast with a clear message if the secret is missing.
- Installs the Firebase CLI + `functions/` deps so the `firebase.json` predeploy build runs, then `firebase deploy --project abot-ko-na --non-interactive --force`.

**One-time setup required before it works** (see PR discussion / chat): generate a Firebase service-account key and add it as the `FIREBASE_SERVICE_ACCOUNT` repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_