### PR TITLE
ci: validate service-account key before Firebase deploy

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -35,7 +35,7 @@ jobs:
         # Needed so the firebase.json predeploy hook (npm run build) can run.
         run: npm ci --prefix functions
 
-      - name: Write service account credentials
+      - name: Write & verify service account credentials
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
         run: |
@@ -44,6 +44,29 @@ jobs:
             exit 1
           fi
           printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/gcp-key.json"
+          node -e '
+            const fs = require("fs");
+            const path = process.env.RUNNER_TEMP + "/gcp-key.json";
+            let raw = fs.readFileSync(path, "utf8").trim();
+            let j;
+            try { j = JSON.parse(raw); }
+            catch (e) {
+              console.error("::error::FIREBASE_SERVICE_ACCOUNT is not valid JSON. Copy the ENTIRE service-account key file as the secret value (no quotes/extra text). Parser said: " + e.message);
+              process.exit(1);
+            }
+            if (j.type !== "service_account") {
+              console.error("::error::This is not a service-account key (type=\"" + j.type + "\"). Generate one in Firebase Console → Project settings → Service accounts → Generate new private key, then paste its full contents.");
+              process.exit(1);
+            }
+            if (!j.private_key || !j.client_email) {
+              console.error("::error::Key is missing private_key/client_email — it looks incomplete.");
+              process.exit(1);
+            }
+            console.log("Service account looks valid: project_id=" + j.project_id + ", client_email=" + String(j.client_email).replace(/@.*/, "@…"));
+            if (j.project_id && j.project_id !== "abot-ko-na") {
+              console.log("::warning::Key project_id (" + j.project_id + ") is not abot-ko-na — deploy may target the wrong project.");
+            }
+          '
           echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/gcp-key.json" >> "$GITHUB_ENV"
 
       - name: Deploy


### PR DESCRIPTION
Follow-up to the deploy workflow. The first real run failed at `firebase deploy` with `Failed to authenticate, have you run firebase login?` even though the `FIREBASE_SERVICE_ACCOUNT` secret was present — which points at the credential JSON being invalid/incomplete rather than an IAM problem.

This adds a **validation step** that parses the secret and fails fast with an actionable, non-secret-leaking message:
- not valid JSON → tells you to re-copy the full file
- wrong `type` (not `service_account`) → tells you where to generate the right key
- missing `private_key`/`client_email` → flags it as incomplete
- prints `project_id` + masked `client_email`, and warns if the project isn't `abot-ko-na`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_