### PR TITLE
ci: wire firestore.rules into firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "functions": [
     {
       "source": "functions",


### PR DESCRIPTION
The deploy run reached `firebase deploy --only firestore:rules` but failed with "No targets in firebase.json match" — because `firebase.json` only declared `functions` and never mapped the Firestore rules file.

This adds the mapping so rules can deploy:
```json
"firestore": { "rules": "firestore.rules" }
```

Note: there is no `firestore.indexes.json` in the repo, so indexes are intentionally not wired (nothing to deploy there).

This is a no-cost deploy target (Firestore rules don't require the Blaze plan). Cloud Functions remain undeployed by choice (they require Blaze).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_