### PR TITLE
fix(rules): unblock new members joining via invite QR

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -53,7 +53,12 @@ service cloud.firestore {
       // === MEMBERS SUBCOLLECTION ===
       match /members/{memberId} {
         allow read: if isSignedIn() && isFamilyMember(familyId);
-        allow create: if isSignedIn() && request.auth.uid == memberId && isFamilyMember(familyId);
+        // A signed-in user may create THEIR OWN member doc to join a family
+        // (the invite QR carries the familyId). Requiring isFamilyMember here
+        // was circular — a new joiner is never a member yet — so it blocked all
+        // joins with permission-denied. Gate on the family existing instead.
+        allow create: if isSignedIn() && request.auth.uid == memberId &&
+          exists(/databases/$(database)/documents/families/$(familyId));
         allow update, delete: if isSignedIn() && (
           request.auth.uid == memberId ||
           isFamilyAdmin(familyId)


### PR DESCRIPTION
## Bug: scanning a family-invite QR → sign-in loop, never joined

Root cause (certain): the Firestore `members/{memberId}` **create** rule required `isFamilyMember(familyId)` — but a brand-new invitee isn't a member yet, so the check is circular and every join write failed with `permission-denied`. The join silently failed → "never joined." (This rule went live in today's rules deploy, so the invite flow is currently broken for all new users.)

### Fix
```
allow create: if isSignedIn() && request.auth.uid == memberId &&
  exists(/databases/$(database)/documents/families/$(familyId));
```
A signed-in user may create **their own** member doc to join, gated on the family existing. This matches the product's invite model (the QR encodes the `familyId` as the invite identifier).

### Security note
This means anyone who has a family's ID (e.g. via the QR/link) can join it — which is exactly what the current QR-invite design intends. Family IDs are random Firestore IDs (not guessable). If you later want stronger invites, a per-invite token doc with expiry would be the upgrade (happy to do that separately).

### Scope / honesty
- This definitively fixes **"never joined"** for signed-in users.
- The reported **sign-in loop** may have a second, separate cause on mobile (`signInWithRedirect` auth-persistence, or a brand-new user being routed through `/onboarding` before the join runs). I couldn't confirm that without the device. Worth re-testing after this deploys.
- No cost to deploy (Firestore rules, no Blaze needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_