### PR TITLE
fix(auth): finalize mobile redirect sign-in (loop)

### DIFF
--- a/src/lib/useAuth.ts
+++ b/src/lib/useAuth.ts
@@ -1,7 +1,7 @@
 // lib/useAuth.ts
 import { useEffect, useState } from 'react'
 import { auth, firestore } from './firebase'
-import { onAuthStateChanged } from 'firebase/auth'
+import { onAuthStateChanged, getRedirectResult } from 'firebase/auth'
 import { doc, onSnapshot, setDoc } from 'firebase/firestore'
 import { ensureUserPresence } from './firestoreUtils'
 
@@ -19,6 +19,13 @@ export function useAuth() {
 
   useEffect(() => {
     let unsubUserDoc: (() => void) | null = null
+
+    // Finalize a pending mobile-redirect sign-in (signInWithRedirect). Without
+    // this, on some mobile browsers the returning redirect isn't completed and
+    // the user lands back on /login still signed-out — the "sign-in loop".
+    getRedirectResult(auth).catch((err) => {
+      console.error('[useAuth] getRedirectResult failed:', err)
+    })
 
     const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
       if (!firebaseUser) {


### PR DESCRIPTION
Second half of the invite-bug fix (the **sign-in loop**), complementing #25 (the rules fix that solved "never joined").

### What this does
Adds a `getRedirectResult(auth)` call on mount in `useAuth`. Mobile/PWA sign-in uses `signInWithRedirect`, but nothing called `getRedirectResult` to finalize the returning redirect — so on some mobile browsers the user came back to `/login` still signed-out and got prompted to sign in again (the loop).

### Honest scope
- This is the recommended, low-risk completion step and resolves the common case.
- If the looping device is specifically **iPhone/Safari**, there may be a deeper cause: the Firebase `authDomain` is the default `*.firebaseapp.com` while the app runs on a different (Vercel) domain, and iOS ITP can break that cross-domain redirect regardless. The robust fix there is serving the auth handler same-origin (Vercel rewrite of `/__/auth/*` → firebaseapp.com + pointing `authDomain` at the app domain). I can set that up if this alone doesn't clear it — needs the production domain + on-device testing.

Verified: `tsc` passes. No cost (frontend; Vercel auto-deploys on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_