### PR TITLE
fix(rules): allow reading the in-app notification feed

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -33,6 +33,22 @@ service cloud.firestore {
         )
       );
       allow update, delete: if isMe(userId);
+
+      // Owner-only access to user-owned subcollections (e.g. the notifications
+      // fallback feed and joined-families records). Keeps them private even
+      // though the user doc itself is readable by family members above.
+      match /{sub=**} {
+        allow read, write: if isMe(userId);
+      }
+    }
+
+    // === IN-APP NOTIFICATION FEED ===
+    // Events are written by Cloud Functions and addressed via a `targets`
+    // array of recipient uids; a user may read events that target them.
+    // The recursive wildcard is required for collectionGroup('events') reads —
+    // without this rule the notifications feed gets permission-denied.
+    match /{path=**}/events/{eventId} {
+      allow read: if isSignedIn() && request.auth.uid in resource.data.targets;
     }
 
     // === FAMILIES ===


### PR DESCRIPTION
## Bug: "missing permission" popup on the notifications area

The in-app notifications feed (`useNotifications`) reads `collectionGroup('events')` filtered by `targets`, but the deployed `firestore.rules` had **no `events` rule at all** — so every read returned `permission-denied`. (This surfaced after today's rules deploy; it's a rule gap, not the notification UI — reverting the UI would not fix it.)

### Fix
- Add a recursive rule required for the collectionGroup read, scoped to the recipient:
  ```
  match /{path=**}/events/{eventId} {
    allow read: if isSignedIn() && request.auth.uid in resource.data.targets;
  }
  ```
  (Aligns with the query's `where('targets','array-contains', uid)`. Events are written by Cloud Functions only, so no client write rule is needed.)
- Add an owner-only rule for user-owned subcollections (the `users/{uid}/notifications` fallback feed and joined-families records), kept private even though the user *doc* is readable by family members.

No cost (Firestore rules). Will deploy via the Firebase Deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_