### PR TITLE
fix(rules): allow the per-delivery notes thread

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -100,6 +100,14 @@ service cloud.firestore {
         match /items/{itemId} {
           allow read, create, update, delete: if isSignedIn() && isFamilyMember(familyId);
         }
+
+        // === DELIVERY NOTES SUBCOLLECTION ===
+        // Shared per-delivery notes thread. Any family member can read and post;
+        // the UI restricts edit/delete to a note's author. Without this rule the
+        // notes thread returns "missing or insufficient permissions".
+        match /notes/{noteId} {
+          allow read, create, update, delete: if isSignedIn() && isFamilyMember(familyId);
+        }
       }
 
       // === SHOPPING LIST SUBCOLLECTION ===


### PR DESCRIPTION
## Bug: delivery notes show "missing or insufficient permissions"

The per-delivery notes thread reads/writes `families/{familyId}/deliveries/{deliveryId}/notes`, but `firestore.rules` had **no `notes` rule** — so it returned *"Missing or insufficient permissions"* / *"You do not have access to notes for this delivery."* (Same class of gap as the events feed.)

### Fix
Add a `notes` subcollection rule mirroring `items`:
```
match /notes/{noteId} {
  allow read, create, update, delete: if isSignedIn() && isFamilyMember(familyId);
}
```
Family members can read and post; the UI already restricts edit/delete to a note's author.

No cost (Firestore rules). Will deploy via the Firebase Deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_