### PR TITLE
feat(theme): cozy warm palette + rounder corners across all pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,72 +44,74 @@
 }
 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  /* Cozy: rounder corners + warm cream/clay palette */
+  --radius: 1rem;
+  --background: oklch(0.985 0.013 90);
+  --foreground: oklch(0.255 0.022 58);
+  --card: oklch(0.995 0.008 92);
+  --card-foreground: oklch(0.255 0.022 58);
+  --popover: oklch(0.995 0.008 92);
+  --popover-foreground: oklch(0.255 0.022 58);
+  --primary: oklch(0.585 0.105 47);
+  --primary-foreground: oklch(0.99 0.012 90);
+  --secondary: oklch(0.955 0.018 86);
+  --secondary-foreground: oklch(0.32 0.03 52);
+  --muted: oklch(0.955 0.018 86);
+  --muted-foreground: oklch(0.53 0.026 58);
+  --accent: oklch(0.93 0.03 78);
+  --accent-foreground: oklch(0.32 0.03 52);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --border: oklch(0.9 0.02 80);
+  --input: oklch(0.9 0.02 80);
+  --ring: oklch(0.7 0.07 60);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar: oklch(0.975 0.016 88);
+  --sidebar-foreground: oklch(0.255 0.022 58);
+  --sidebar-primary: oklch(0.585 0.105 47);
+  --sidebar-primary-foreground: oklch(0.99 0.012 90);
+  --sidebar-accent: oklch(0.93 0.03 78);
+  --sidebar-accent-foreground: oklch(0.32 0.03 52);
+  --sidebar-border: oklch(0.9 0.02 80);
+  --sidebar-ring: oklch(0.7 0.07 60);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  /* Cozy dark: warm charcoal + amber glow */
+  --background: oklch(0.195 0.014 58);
+  --foreground: oklch(0.965 0.01 85);
+  --card: oklch(0.235 0.015 58);
+  --card-foreground: oklch(0.965 0.01 85);
+  --popover: oklch(0.235 0.015 58);
+  --popover-foreground: oklch(0.965 0.01 85);
+  --primary: oklch(0.72 0.11 58);
+  --primary-foreground: oklch(0.22 0.03 50);
+  --secondary: oklch(0.285 0.016 58);
+  --secondary-foreground: oklch(0.965 0.01 85);
+  --muted: oklch(0.285 0.016 58);
+  --muted-foreground: oklch(0.72 0.022 74);
+  --accent: oklch(0.31 0.022 60);
+  --accent-foreground: oklch(0.965 0.01 85);
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --ring: oklch(0.55 0.05 60);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar: oklch(0.235 0.015 58);
+  --sidebar-foreground: oklch(0.965 0.01 85);
+  --sidebar-primary: oklch(0.72 0.11 58);
+  --sidebar-primary-foreground: oklch(0.22 0.03 50);
+  --sidebar-accent: oklch(0.31 0.022 60);
+  --sidebar-accent-foreground: oklch(0.965 0.01 85);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar-ring: oklch(0.55 0.05 60);
 }
 
 @layer base {


### PR DESCRIPTION
Makes the **whole app** cozy/homey, not just Home — and dials the warmth up.

Rather than restyle every page by hand, this warms the **design tokens** every page already uses, so the cozy feel lands everywhere at once:

- **Cream/ivory backgrounds** (light) and **warm charcoal** (dark) instead of pure white/black
- **Clay/terracotta primary** — filled buttons, links, focus rings, accents all read warm
- **"Espresso" text** (soft warm near-black) instead of stark black
- **Warm borders + muted surfaces**, warm amber glow in dark mode
- **Rounder everything** — base radius `0.625rem → 1rem`, so cards/buttons/inputs are softer app-wide

No per-page edits, no layout or logic changes — purely the theme. Verified the app is token-driven (only modal scrims use a fixed color), so there are no clashing hardcoded backgrounds.

Verified: `next build` passes. Frontend only — Vercel auto-deploys on merge.

Note: this is a bold, app-wide color shift done without a live preview — easy to dial the terracotta/cream intensity up or down once it's deployed and you've looked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_