### PR TITLE
style: breathing room across Family, Shopping, Settings, Notifications

### DIFF
--- a/src/app/(main)/family/FamilyPickerPage.tsx
+++ b/src/app/(main)/family/FamilyPickerPage.tsx
@@ -196,6 +196,7 @@ export default function FamilyPickerPage() {
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0 }}
         transition={{ type: 'spring', stiffness: 260, damping: 22 }}
+        className="mb-3 last:mb-0"
       >
         <Card
           role="button"
@@ -240,8 +241,8 @@ export default function FamilyPickerPage() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto p-4">
-      <div className="flex items-center justify-between mb-4">
+    <div className="max-w-2xl mx-auto px-5 py-8">
+      <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-semibold">Your Families</h1>
         <div className="flex gap-2">
           <Button variant="outline" onClick={() => setJoinOpen(true)}>Join</Button>

--- a/src/app/(main)/notifications/page.tsx
+++ b/src/app/(main)/notifications/page.tsx
@@ -182,7 +182,7 @@ export default function NotificationsPage() {
 
   return (
     <main
-      className="mx-auto w-full max-w-2xl p-4 md:p-6 leading-tight"
+      className="mx-auto w-full max-w-2xl px-5 py-7 md:px-6"
       style={{ WebkitFontSmoothing: 'antialiased' }}
     >
       {!isOnline && (
@@ -194,7 +194,7 @@ export default function NotificationsPage() {
       {/* Header — mark as no-swipe to keep it tappable on mobile */}
       <div
         data-no-swipe
-        className="mb-3 flex items-center justify-between gap-2 sm:gap-3 pointer-events-auto"
+        className="mb-5 flex items-center justify-between gap-2 sm:gap-3 pointer-events-auto"
       >
         <div className="flex items-center gap-2 min-h-[44px]">
           <Bell className="h-5 w-5 shrink-0" />
@@ -293,7 +293,7 @@ export default function NotificationsPage() {
 
       <Separator />
 
-      <div className="mt-4 space-y-2" aria-busy={loading ? 'true' : 'false'} aria-live="polite">
+      <div className="mt-5 space-y-3" aria-busy={loading ? 'true' : 'false'} aria-live="polite">
         {loading && (
           <>
             {Array.from({ length: 6 }).map((_, i) => (

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -153,7 +153,7 @@ export default function SettingsPage() {
   return (
     <>
       {offlineBanner}
-      <main className="mx-auto w-full max-w-2xl p-6 space-y-6">
+      <main className="mx-auto w-full max-w-2xl px-5 py-8 space-y-7">
         <div className="space-y-2">
           <h1 className="text-xl font-semibold">Settings</h1>
           <Separator />

--- a/src/app/(main)/shopping/page.tsx
+++ b/src/app/(main)/shopping/page.tsx
@@ -156,7 +156,7 @@ export default function ShoppingListPage() {
   }
 
   return (
-    <main className="max-w-2xl mx-auto p-6 space-y-6">
+    <main className="max-w-2xl mx-auto px-5 py-8 space-y-7">
       <div className="flex items-center gap-3">
         <Link href="/" className="text-muted-foreground hover:text-foreground" aria-label="Back to home">
           <ArrowLeft className="h-5 w-5" />


### PR DESCRIPTION
Extends the Deliveries breathing-room pass to the rest of the main screens, per "feels a bit crowded." Spacing-only:

- **Family** — container `p-4 → px-5 py-8`; **a real gap between family cards** (they were rendered flush with no spacing); header margin bumped.
- **Shopping** — `p-6 space-y-6 → px-5 py-8 space-y-7`.
- **Settings** — `p-6 space-y-6 → px-5 py-8 space-y-7`.
- **Notifications** — roomier padding, removed the cramped `leading-tight`, header `mb-3 → mb-5`, list items `space-y-2 → space-y-3`.

No logic changes. `next build` passes. Vercel auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_