### PR TITLE
style(home): declutter the Who's-home member rows

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -18,10 +18,7 @@ import { Loader2, Home as HomeIcon, DoorOpen, MapPin, ShoppingCart, Truck, X, Be
 import { Skeleton } from '@/components/ui/skeleton'
 import { useAutoPresence } from '@/lib/useAutoPresence'
 import {
-  Tooltip,
-  TooltipContent,
   TooltipProvider,
-  TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { formatDistanceToNow } from 'date-fns'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -492,31 +489,6 @@ export default function HomePage() {
                                       {watchingMember ? <BellRing className="h-4 w-4" /> : <Bell className="h-4 w-4" />}
                                     </motion.button>
                                   )}
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <span className="text-[10px] px-2 py-0.5 rounded bg-muted text-muted-foreground border border-muted-foreground/10 cursor-default">
-                                        {presence.source === 'geo' ? 'Auto' : presence.source === 'manual' ? 'Manual' : '—'}
-                                      </span>
-                                    </TooltipTrigger>
-                                    <TooltipContent side="top" align="end">
-                                      <p>
-                                        {presence.source === 'geo'
-                                          ? 'Set automatically based on location'
-                                          : presence.source === 'manual'
-                                            ? 'Manually set by user'
-                                            : 'No source available'}
-                                      </p>
-                                      {updatedDate && (
-                                        <p className="text-xs text-muted-foreground">
-                                          Updated {formatDistanceToNow(updatedDate, { addSuffix: true })}
-                                        </p>
-                                      )}
-                                    </TooltipContent>
-                                  </Tooltip>
-
-                                  <div className="text-xs text-muted-foreground sm:hidden">
-                                    {updatedDate ? formatDistanceToNow(updatedDate, { addSuffix: true }) : 'unknown time'}
-                                  </div>
                                 </div>
                               </motion.div>
                             )


### PR DESCRIPTION
Judgment call after seeing the live screens: the app reads cozy + spacious now, but the **"Who's home" rows on Home** were the one cluttered spot — each member repeated their source and timestamp twice (the status line *and* a second row with an Auto/Manual badge + duplicate time).

This keeps the single clean status line ("Away · Manual · 10 months ago") + the watch bell, and removes the redundant tooltip badge and duplicate timestamp. Also trims the now-unused Tooltip imports.

`tsc` + `next build` pass. Frontend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_