### PR TITLE
feat(home): visualize auto-presence on a Family map

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -40,8 +40,15 @@ import {
   normalizeMemberSource,
   normalizeMember,
 } from '@/lib/models/presence'
-import { hasHomeLocation as familyHasHomeLocation } from '@/lib/models/family'
+import { hasHomeLocation as familyHasHomeLocation, getHomeLocation } from '@/lib/models/family'
 import { setEnRoute, clearEnRoute, ETA_OPTIONS } from '@/lib/enroute'
+import dynamic from 'next/dynamic'
+import type { PresenceMember } from '../components/PresenceMap'
+
+const PresenceMap = dynamic(() => import('../components/PresenceMap'), {
+  ssr: false,
+  loading: () => <Skeleton className="h-[260px] w-full rounded-2xl" />,
+})
 
 export default function HomePage() {
   const { user, loading: authLoading } = useAuth()
@@ -119,15 +126,21 @@ export default function HomePage() {
 
   // Family Home Location detector (robust: GeoPoint | {lat,lng} | {lat,lon} | legacy fields)
   const [hasHomeLocation, setHasHomeLocation] = useState<boolean | null>(null)
+  const [homeLoc, setHomeLoc] = useState<{ lat: number; lng: number } | null>(null)
+  const [homeRadius, setHomeRadius] = useState<number>(120)
   useEffect(() => {
-    if (!familyId) { setHasHomeLocation(null); return }
+    if (!familyId) { setHasHomeLocation(null); setHomeLoc(null); return }
 
     const unsub = onSnapshot(
       doc(firestore, 'families', familyId),
       (snap) => {
-        setHasHomeLocation(familyHasHomeLocation(snap.data()))
+        const data = snap.data()
+        setHasHomeLocation(familyHasHomeLocation(data))
+        setHomeLoc(getHomeLocation(data))
+        const r = (data as any)?.homeRadiusMeters
+        setHomeRadius(typeof r === 'number' && Number.isFinite(r) ? Math.max(30, Math.min(1000, r)) : 120)
       },
-      () => setHasHomeLocation(false)
+      () => { setHasHomeLocation(false); setHomeLoc(null) }
     )
     return () => unsub()
   }, [familyId])
@@ -260,6 +273,33 @@ export default function HomePage() {
   const greeting = hour < 12 ? 'Good morning' : hour < 18 ? 'Good afternoon' : 'Good evening'
   const greetEmoji = hour < 12 ? '☀️' : hour < 18 ? '🌤️' : '🌙'
   const firstName = (user?.name ?? '').trim().split(' ')[0] || ''
+
+  // Members with auto-presence on that have a last-known location → map pins.
+  const mapMembers: PresenceMember[] = membersLive
+    .map((m) => {
+      const lg = (m as any).lastGeo
+      const lat = lg?.lat, lng = lg?.lng
+      if (typeof lat !== 'number' || typeof lng !== 'number') return null
+      const auto =
+        (m as any).statusSource === 'geo' ||
+        (m as any).autoPresence === true ||
+        (m as any).presence?.statusSource === 'geo'
+      if (!auto) return null
+      const ts = lg?.updatedAt?.toDate
+        ? lg.updatedAt.toDate().getTime()
+        : typeof lg?.updatedAt?.seconds === 'number'
+          ? lg.updatedAt.seconds * 1000
+          : null
+      return {
+        uid: m.uid as string,
+        name: ((m as any).name as string) ?? 'Member',
+        status: normalizeMemberStatus(m) as 'home' | 'away' | null,
+        lat,
+        lng,
+        updatedAt: ts,
+      }
+    })
+    .filter((x): x is PresenceMember => x !== null)
 
   return (
     <>
@@ -521,6 +561,26 @@ export default function HomePage() {
             )}
           </CardContent>
         </Card>
+
+        {familyId && homeLoc && (
+          <Card className="rounded-3xl border-border/60 shadow-sm shadow-black/[0.03]">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2.5">
+                <span className="inline-flex h-8 w-8 items-center justify-center rounded-2xl bg-rose-500/10 text-rose-600">
+                  <MapPin className="h-4 w-4" />
+                </span>
+                Family map
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2.5">
+              <PresenceMap home={homeLoc} radius={homeRadius} members={mapMembers} />
+              <p className="text-xs text-muted-foreground">
+                Home 🏡 and the last-known spots of members with auto-presence on — updated when someone arrives or leaves.
+                {mapMembers.length === 0 && ' No member locations to show yet.'}
+              </p>
+            </CardContent>
+          </Card>
+        )}
 
         <Card className="rounded-3xl border-border/60 shadow-sm shadow-black/[0.03]">
           <CardHeader>

--- a/src/app/components/PresenceMap.tsx
+++ b/src/app/components/PresenceMap.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { MapContainer, TileLayer, Marker, Circle, Popup, useMap } from 'react-leaflet'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+import { useEffect } from 'react'
+import { formatDistanceToNow } from 'date-fns'
+
+// Leaflet's default marker asset paths break under bundlers — point them at /public.
+delete (L.Icon.Default as unknown as { prototype: { _getIconUrl?: unknown } }).prototype._getIconUrl
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: '/leaflet/marker-icon.png',
+  iconUrl: '/leaflet/marker-icon.png',
+  shadowUrl: '/leaflet/marker-shadow.png',
+})
+
+const homeIcon = L.icon({
+  iconUrl: '/leaflet/marker-icon-red.png',
+  shadowUrl: '/leaflet/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+})
+
+export type PresenceMember = {
+  uid: string
+  name: string
+  status: 'home' | 'away' | null
+  lat: number
+  lng: number
+  updatedAt: number | null
+}
+
+/** Frame the map to show home + all member pins. */
+function FitBounds({ points }: { points: [number, number][] }) {
+  const map = useMap()
+  useEffect(() => {
+    if (points.length <= 1) {
+      if (points[0]) map.setView(points[0], 16)
+      return
+    }
+    map.fitBounds(points, { padding: [44, 44], maxZoom: 16 })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(points)])
+  return null
+}
+
+export default function PresenceMap({
+  home,
+  radius,
+  members,
+}: {
+  home: { lat: number; lng: number }
+  radius: number
+  members: PresenceMember[]
+}) {
+  const points: [number, number][] = [
+    [home.lat, home.lng],
+    ...members.map((m) => [m.lat, m.lng] as [number, number]),
+  ]
+
+  return (
+    <MapContainer
+      center={[home.lat, home.lng]}
+      zoom={16}
+      scrollWheelZoom={false}
+      className="h-[260px] w-full rounded-2xl z-0"
+    >
+      <TileLayer
+        attribution="&copy; OpenStreetMap contributors"
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+
+      {/* Home + its presence radius */}
+      <Circle
+        center={[home.lat, home.lng]}
+        radius={radius}
+        pathOptions={{ color: '#b45309', fillColor: '#d97706', fillOpacity: 0.08, weight: 1.5 }}
+      />
+      <Marker position={[home.lat, home.lng]} icon={homeIcon}>
+        <Popup>🏡 Home</Popup>
+      </Marker>
+
+      {/* Members with auto-presence on */}
+      {members.map((m) => (
+        <Marker key={m.uid} position={[m.lat, m.lng]}>
+          <Popup>
+            <div className="text-sm font-medium">{m.name}</div>
+            <div className="text-xs">{m.status === 'home' ? '🏠 Home' : '🚪 Out'} · Auto</div>
+            {m.updatedAt && (
+              <div className="text-xs opacity-70">
+                Updated {formatDistanceToNow(new Date(m.updatedAt), { addSuffix: true })}
+              </div>
+            )}
+          </Popup>
+        </Marker>
+      ))}
+
+      <FitBounds points={points} />
+    </MapContainer>
+  )
+}


### PR DESCRIPTION
Visualizes auto-presence on a map, as requested.

Adds a **"Family map" card** on Home (shown only when a family home location is set):
- 🏡 **Home marker** + a **radius circle** for the auto-presence zone (uses `homeRadiusMeters`, default 120m)
- 📍 A **pin per member** whose auto-presence is on, at their last-known spot — popup shows name, home/out, and "updated X ago"
- Auto-frames to fit home + all pins

### Built from existing data — no new tracking
`useAutoPresence` already writes `lastGeo {lat,lng,accuracy,updatedAt}` to each member's doc on status changes, and those docs are already readable by family members. This just *visualizes* what's there. Pins are **last-known** (updated when someone arrives/leaves), not continuous live tracking — labeled as such in the card.

Implementation: reuses the app's existing Leaflet/react-leaflet setup; map is `dynamic(..., { ssr: false })` to avoid SSR issues. `tsc` + `next build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_