### PR TITLE
feat(map): avatar pins + more-live member locations

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -275,31 +275,31 @@ export default function HomePage() {
   const firstName = (user?.name ?? '').trim().split(' ')[0] || ''
 
   // Members with auto-presence on that have a last-known location → map pins.
-  const mapMembers: PresenceMember[] = membersLive
-    .map((m) => {
-      const lg = (m as any).lastGeo
-      const lat = lg?.lat, lng = lg?.lng
-      if (typeof lat !== 'number' || typeof lng !== 'number') return null
-      const auto =
-        (m as any).statusSource === 'geo' ||
-        (m as any).autoPresence === true ||
-        (m as any).presence?.statusSource === 'geo'
-      if (!auto) return null
-      const ts = lg?.updatedAt?.toDate
-        ? lg.updatedAt.toDate().getTime()
-        : typeof lg?.updatedAt?.seconds === 'number'
-          ? lg.updatedAt.seconds * 1000
-          : null
-      return {
-        uid: m.uid as string,
-        name: ((m as any).name as string) ?? 'Member',
-        status: normalizeMemberStatus(m) as 'home' | 'away' | null,
-        lat,
-        lng,
-        updatedAt: ts,
-      }
-    })
-    .filter((x): x is PresenceMember => x !== null)
+  const mapMembers: PresenceMember[] = membersLive.flatMap((m) => {
+    const lg = (m as any).lastGeo
+    const lat = lg?.lat, lng = lg?.lng
+    if (typeof lat !== 'number' || typeof lng !== 'number') return []
+    const auto =
+      (m as any).statusSource === 'geo' ||
+      (m as any).autoPresence === true ||
+      (m as any).presence?.statusSource === 'geo'
+    if (!auto) return []
+    const ts = lg?.updatedAt?.toDate
+      ? lg.updatedAt.toDate().getTime()
+      : typeof lg?.updatedAt?.seconds === 'number'
+        ? lg.updatedAt.seconds * 1000
+        : null
+    const pm: PresenceMember = {
+      uid: m.uid as string,
+      name: ((m as any).name as string) ?? 'Member',
+      photoURL: ((m as any).photoURL as string | null) ?? null,
+      status: normalizeMemberStatus(m) as 'home' | 'away' | null,
+      lat,
+      lng,
+      updatedAt: ts,
+    }
+    return [pm]
+  })
 
   return (
     <>

--- a/src/app/components/PresenceMap.tsx
+++ b/src/app/components/PresenceMap.tsx
@@ -14,18 +14,52 @@ L.Icon.Default.mergeOptions({
   shadowUrl: '/leaflet/marker-shadow.png',
 })
 
-const homeIcon = L.icon({
-  iconUrl: '/leaflet/marker-icon-red.png',
-  shadowUrl: '/leaflet/marker-shadow.png',
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -34],
-  shadowSize: [41, 41],
+const homeDivIcon = L.divIcon({
+  className: 'presence-pin',
+  html:
+    `<div style="width:40px;height:40px;border-radius:9999px;background:#b45309;` +
+    `display:flex;align-items:center;justify-content:center;font-size:18px;` +
+    `border:2.5px solid #fff;box-shadow:0 2px 6px rgba(0,0,0,.3);">🏡</div>`,
+  iconSize: [40, 40],
+  iconAnchor: [20, 20],
+  popupAnchor: [0, -22],
 })
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string
+  ))
+}
+
+function initialsOf(name: string): string {
+  return (
+    name.trim().split(/\s+/).map((p) => p[0]).join('').slice(0, 2).toUpperCase() || '?'
+  )
+}
+
+/** Google-Maps-style avatar pin: photo if available, else initials chip. */
+function memberIcon(m: PresenceMember): L.DivIcon {
+  const ring = m.status === 'home' ? '#16a34a' : '#9ca3af'
+  const inner = m.photoURL
+    ? `<img src="${escapeHtml(m.photoURL)}" alt="" referrerpolicy="no-referrer" style="width:100%;height:100%;object-fit:cover;border-radius:9999px;" />`
+    : `<div style="width:100%;height:100%;display:flex;align-items:center;justify-content:center;` +
+      `border-radius:9999px;background:linear-gradient(135deg,#f5d0a9,#f8e4c9);color:#92400e;` +
+      `font-weight:600;font-size:13px;font-family:system-ui,-apple-system,sans-serif;">${escapeHtml(initialsOf(m.name))}</div>`
+  return L.divIcon({
+    className: 'presence-pin',
+    html:
+      `<div style="width:38px;height:38px;border-radius:9999px;background:#fff;padding:2px;` +
+      `box-sizing:border-box;border:2.5px solid ${ring};box-shadow:0 2px 6px rgba(0,0,0,.3);">${inner}</div>`,
+    iconSize: [38, 38],
+    iconAnchor: [19, 19],
+    popupAnchor: [0, -20],
+  })
+}
 
 export type PresenceMember = {
   uid: string
   name: string
+  photoURL?: string | null
   status: 'home' | 'away' | null
   lat: number
   lng: number
@@ -78,13 +112,13 @@ export default function PresenceMap({
         radius={radius}
         pathOptions={{ color: '#b45309', fillColor: '#d97706', fillOpacity: 0.08, weight: 1.5 }}
       />
-      <Marker position={[home.lat, home.lng]} icon={homeIcon}>
+      <Marker position={[home.lat, home.lng]} icon={homeDivIcon}>
         <Popup>🏡 Home</Popup>
       </Marker>
 
       {/* Members with auto-presence on */}
       {members.map((m) => (
-        <Marker key={m.uid} position={[m.lat, m.lng]}>
+        <Marker key={m.uid} position={[m.lat, m.lng]} icon={memberIcon(m)}>
           <Popup>
             <div className="text-sm font-medium">{m.name}</div>
             <div className="text-xs">{m.status === 'home' ? '🏠 Home' : '🚪 Out'} · Auto</div>

--- a/src/lib/useAutoPresence.ts
+++ b/src/lib/useAutoPresence.ts
@@ -27,6 +27,8 @@ export function useAutoPresence(familyId?: string | null) {
   const lastStatusRef = useRef<'home' | 'away' | null>(null)
   const lastWriteAtRef = useRef<number>(0)
   const lastPosRef = useRef<{ lat: number; lng: number; acc?: number } | null>(null)
+  const lastGeoWriteAtRef = useRef<number>(0)
+  const lastGeoPosRef = useRef<{ lat: number; lng: number } | null>(null)
   const unsubFamilyRef = useRef<null | (() => void)>(null)
 
   const debug = () => (typeof window !== 'undefined' && localStorage.getItem('debugAutoPresence') === '1')
@@ -41,6 +43,7 @@ export function useAutoPresence(familyId?: string | null) {
         const { latitude, longitude, accuracy } = pos.coords
         lastPosRef.current = { lat: latitude, lng: longitude, acc: accuracy }
         evaluate(latitude, longitude, accuracy)
+        void maybeWriteGeo(latitude, longitude, accuracy)
       },
       (err) => {
         if (debug()) console.warn('[autoPresence] watch error', err)
@@ -97,6 +100,29 @@ export function useAutoPresence(familyId?: string | null) {
       },
       { merge: true }
     )
+  }
+
+  // Keep the map fresh: periodically persist the live position (throttled by
+  // time + distance) so member pins move, not just on home/away transitions.
+  async function maybeWriteGeo(lat: number, lng: number, accuracy?: number) {
+    const user = auth.currentUser
+    if (!user || !familyId) return
+    const now = Date.now()
+    if (now - lastGeoWriteAtRef.current < 60_000) return // at most once per minute
+    const last = lastGeoPosRef.current
+    if (last && haversine(lat, lng, last.lat, last.lng) < 25) return // skip if barely moved
+    lastGeoWriteAtRef.current = now
+    lastGeoPosRef.current = { lat, lng }
+    try {
+      await setDoc(
+        doc(firestore, 'families', familyId, 'members', user.uid),
+        { lastGeo: { lat, lng, accuracy: accuracy ?? null, updatedAt: serverTimestamp() }, uid: user.uid },
+        { merge: true }
+      )
+      if (debug()) console.log('[autoPresence] live geo write', { lat, lng })
+    } catch (e) {
+      if (debug()) console.warn('[autoPresence] live geo write failed', e)
+    }
   }
 
   function evaluate(lat: number, lng: number, accuracy?: number) {


### PR DESCRIPTION
Two requested upgrades to the Family map:

### 1. Avatar pins (with Google-style initials fallback)
- Member pins now render the member's **avatar photo** in a circular pin with a **status-colored ring** (green = home, grey = out).
- No photo? → a warm **initials chip** (like Google Maps), e.g. "GR".
- Home is now a cozy **🏡 house pin**.
- Built with `L.divIcon` + inline styles (HTML-escaped); `referrerpolicy="no-referrer"` so Google/Firebase avatar URLs load.

### 2. More live
`useAutoPresence` now **persists position periodically**, not only on home/away transitions:
- Writes `lastGeo` at most **once per minute** and only when moved **>25m** (so pins track movement without spamming Firestore or draining battery).
- Status logic unchanged.

### Honest notes
- Still **best-effort while the app is open** — browsers suspend geolocation in the background, so this isn't true always-on tracking.
- It does mean **more frequent location writes** for members with location active (the live-ness you asked for). Family members could already read these docs; this just refreshes them more often. Easy to dial the cadence (1 min / 25 m) up or down.

`tsc` + `next build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_