### PR TITLE
fix(auth): popup sign-in on mobile browsers to stop iOS loop

### DIFF
--- a/src/lib/auth-signin.ts
+++ b/src/lib/auth-signin.ts
@@ -4,16 +4,18 @@
 import { signInWithPopup, signInWithRedirect } from 'firebase/auth'
 import { auth, provider } from '@/lib/firebase'
 
-/** iOS Safari and installed PWAs block auth popups, so prefer redirect there. */
+/**
+ * Only installed PWAs need the redirect flow (they block popups). Mobile
+ * browsers can use a popup, which returns the credential via postMessage to
+ * our own origin — avoiding the iOS Safari / ITP cross-domain redirect loop.
+ */
 function prefersRedirect(): boolean {
   if (typeof navigator === 'undefined' || typeof window === 'undefined') return false
-  const ua = navigator.userAgent || ''
-  const isMobileUA = /iPhone|iPad|iPod|Android/i.test(ua)
   const isStandalone =
     window.matchMedia?.('(display-mode: standalone)')?.matches === true ||
     // iOS Safari "Add to Home Screen"
     (navigator as unknown as { standalone?: boolean }).standalone === true
-  return isMobileUA || isStandalone
+  return isStandalone
 }
 
 /**


### PR DESCRIPTION
Fixes the recurring **iOS sign-in loop**.

**Cause:** redirect sign-in bounces through `abot-ko-na.firebaseapp.com` and back to the app's domain. iOS Safari's ITP breaks that cross-domain storage, so you return still logged-out → loop. (`getRedirectResult` couldn't recover it — the session never persisted.)

**Fix:** use a **popup** on mobile browsers. A popup returns the credential via `postMessage` to our **own origin**, so auth persists in our own IndexedDB — no cross-domain storage, no loop. Redirect is kept only for **installed PWAs** (which block popups), and the existing redirect fallback still covers a blocked popup.

Net change: mobile browsers go redirect → popup; desktop already used popup (unchanged); PWA unchanged.

`tsc` + `next build` pass.

Note: if it still loops **inside the installed PWA** (home-screen app, where popups are blocked), that needs the heavier same-origin auth-handler proxy (Vercel rewrite of `/__/auth/*` + authDomain = app domain) — I can do that next if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_