### PR TITLE
fix(map): drop stale pins + refresh location on app open

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -275,6 +275,8 @@ export default function HomePage() {
   const firstName = (user?.name ?? '').trim().split(' ')[0] || ''
 
   // Members with auto-presence on that have a last-known location → map pins.
+  // Members with auto-presence on that have a RECENT last-known location → map pins.
+  const FRESH_MS = 3 * 60 * 60 * 1000 // 3 hours
   const mapMembers: PresenceMember[] = membersLive.flatMap((m) => {
     const lg = (m as any).lastGeo
     const lat = lg?.lat, lng = lg?.lng
@@ -289,6 +291,8 @@ export default function HomePage() {
       : typeof lg?.updatedAt?.seconds === 'number'
         ? lg.updatedAt.seconds * 1000
         : null
+    // Skip stale fixes (e.g. months-old) so the map shows current-ish positions.
+    if (ts == null || Date.now() - ts > FRESH_MS) return []
     const pm: PresenceMember = {
       uid: m.uid as string,
       name: ((m as any).name as string) ?? 'Member',
@@ -575,8 +579,9 @@ export default function HomePage() {
             <CardContent className="space-y-2.5">
               <PresenceMap home={homeLoc} radius={homeRadius} members={mapMembers} />
               <p className="text-xs text-muted-foreground">
-                Home 🏡 and the last-known spots of members with auto-presence on — updated when someone arrives or leaves.
-                {mapMembers.length === 0 && ' No member locations to show yet.'}
+                Home 🏡 and recent spots of members with auto-presence on. Locations refresh while the app is open
+                (the web can’t track in the background), so they can lag a little.
+                {mapMembers.length === 0 && ' No recent member locations to show.'}
               </p>
             </CardContent>
           </Card>

--- a/src/lib/useAutoPresence.ts
+++ b/src/lib/useAutoPresence.ts
@@ -54,6 +54,21 @@ export function useAutoPresence(familyId?: string | null) {
         timeout: 25_000,
       }
     )
+
+    // One-shot FRESH fix (maximumAge: 0) so opening the app snaps the map/status
+    // to where you actually are, instead of a cached/stale position.
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude, accuracy } = pos.coords
+        lastPosRef.current = { lat: latitude, lng: longitude, acc: accuracy }
+        evaluate(latitude, longitude, accuracy)
+        void maybeWriteGeo(latitude, longitude, accuracy)
+      },
+      (err) => {
+        if (debug()) console.warn('[autoPresence] one-shot error', err)
+      },
+      { enableHighAccuracy: true, maximumAge: 0, timeout: 20_000 }
+    )
     if (debug()) console.log('[autoPresence] watch started', watchIdRef.current)
   }
 


### PR DESCRIPTION
Fixes the "location is messed up / I'm still at home" report on the Family map.

**Two real problems:**
1. The map plotted **months-old** `lastGeo` positions (members inactive for 6–10 months), which zoomed it way out and made it look wrong.
2. The web **can't track location in the background**, so leaving home with the app closed left your pin at the last spot it saw you (near home) even though your status correctly flipped to "Away."

**Fixes:**
- **Only plot recent locations** — pins older than 3 hours are dropped, so the map shows current-ish positions, not ancient ones.
- **One-shot fresh GPS read** (`maximumAge: 0`) when auto-presence starts, so opening the app snaps your pin (and status) to where you actually are instead of a cached position.
- **Honest copy** on the card: locations only refresh while the app is open.

`tsc` + `next build` pass.

Note on the underlying limit: true always-on location would require a native app or background geofencing — the web can only update while the page is open. This makes "while open" as accurate as possible and stops showing stale/misleading pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_