### PR TITLE
fix(map): show fresh pins + tap-to-locate + cozier map

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,7 +1,7 @@
 // src/app/(main)/page.tsx
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useAuth } from '@/lib/useAuth'
@@ -61,6 +61,10 @@ export default function HomePage() {
 
   const [membersLive, setMembersLive] = useState<RawMember[]>([])
   const [membersLoading, setMembersLoading] = useState(true)
+
+  // Map focus (tap a member to fly to them) + ref to scroll the map into view.
+  const [focusTarget, setFocusTarget] = useState<{ lat: number; lng: number } | null>(null)
+  const mapCardRef = useRef<HTMLDivElement | null>(null)
 
   const [createOpen, setCreateOpen] = useState(false)
   const [joinOpen, setJoinOpen] = useState(false)
@@ -291,8 +295,9 @@ export default function HomePage() {
       : typeof lg?.updatedAt?.seconds === 'number'
         ? lg.updatedAt.seconds * 1000
         : null
-    // Skip stale fixes (e.g. months-old) so the map shows current-ish positions.
-    if (ts == null || Date.now() - ts > FRESH_MS) return []
+    // Hide only confidently-stale fixes (e.g. months-old). A null timestamp means
+    // the server write is still pending (the freshest case) — keep it.
+    if (ts != null && Date.now() - ts > FRESH_MS) return []
     const pm: PresenceMember = {
       uid: m.uid as string,
       name: ((m as any).name as string) ?? 'Member',
@@ -304,6 +309,16 @@ export default function HomePage() {
     }
     return [pm]
   })
+
+  const locateMember = (uid: string, name: string) => {
+    const pin = mapMembers.find((p) => p.uid === uid)
+    if (!pin) {
+      toast(`No recent location for ${name}`)
+      return
+    }
+    setFocusTarget({ lat: pin.lat, lng: pin.lng })
+    mapCardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
 
   return (
     <>
@@ -520,6 +535,17 @@ export default function HomePage() {
                                 </div>
 
                                 <div className="flex items-center gap-2">
+                                  <motion.button
+                                    type="button"
+                                    whileTap={{ scale: 0.82 }}
+                                    transition={{ type: 'spring', stiffness: 400, damping: 17 }}
+                                    onClick={() => locateMember(m.uid as string, presence.name)}
+                                    aria-label={`Show ${presence.name} on the map`}
+                                    title="Show on map"
+                                    className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                                  >
+                                    <MapPin className="h-4 w-4" />
+                                  </motion.button>
                                   {!isCurrentUser && (
                                     <motion.button
                                       type="button"
@@ -567,24 +593,26 @@ export default function HomePage() {
         </Card>
 
         {familyId && homeLoc && (
-          <Card className="rounded-3xl border-border/60 shadow-sm shadow-black/[0.03]">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2.5">
-                <span className="inline-flex h-8 w-8 items-center justify-center rounded-2xl bg-rose-500/10 text-rose-600">
-                  <MapPin className="h-4 w-4" />
-                </span>
-                Family map
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2.5">
-              <PresenceMap home={homeLoc} radius={homeRadius} members={mapMembers} />
-              <p className="text-xs text-muted-foreground">
-                Home 🏡 and recent spots of members with auto-presence on. Locations refresh while the app is open
-                (the web can’t track in the background), so they can lag a little.
-                {mapMembers.length === 0 && ' No recent member locations to show.'}
-              </p>
-            </CardContent>
-          </Card>
+          <div ref={mapCardRef}>
+            <Card className="rounded-3xl border-border/60 shadow-sm shadow-black/[0.03]">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2.5">
+                  <span className="inline-flex h-8 w-8 items-center justify-center rounded-2xl bg-rose-500/10 text-rose-600">
+                    <MapPin className="h-4 w-4" />
+                  </span>
+                  Family map
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2.5">
+                <PresenceMap home={homeLoc} radius={homeRadius} members={mapMembers} focus={focusTarget} />
+                <p className="text-xs text-muted-foreground">
+                  Home 🏡 and recent spots of members with auto-presence on. Tap the 📍 on a member to fly there.
+                  Locations refresh while the app is open (the web can’t track in the background), so they can lag a little.
+                  {mapMembers.length === 0 && ' No recent member locations to show.'}
+                </p>
+              </CardContent>
+            </Card>
+          </div>
         )}
 
         <Card className="rounded-3xl border-border/60 shadow-sm shadow-black/[0.03]">

--- a/src/app/components/PresenceMap.tsx
+++ b/src/app/components/PresenceMap.tsx
@@ -3,7 +3,7 @@
 import { MapContainer, TileLayer, Marker, Circle, Popup, useMap } from 'react-leaflet'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 
 // Leaflet's default marker asset paths break under bundlers — point them at /public.
@@ -17,12 +17,12 @@ L.Icon.Default.mergeOptions({
 const homeDivIcon = L.divIcon({
   className: 'presence-pin',
   html:
-    `<div style="width:40px;height:40px;border-radius:9999px;background:#b45309;` +
-    `display:flex;align-items:center;justify-content:center;font-size:18px;` +
-    `border:2.5px solid #fff;box-shadow:0 2px 6px rgba(0,0,0,.3);">🏡</div>`,
-  iconSize: [40, 40],
-  iconAnchor: [20, 20],
-  popupAnchor: [0, -22],
+    `<div style="width:42px;height:42px;border-radius:9999px;background:#b45309;` +
+    `display:flex;align-items:center;justify-content:center;font-size:19px;` +
+    `border:3px solid #fff;box-shadow:0 3px 8px rgba(0,0,0,.28);">🏡</div>`,
+  iconSize: [42, 42],
+  iconAnchor: [21, 21],
+  popupAnchor: [0, -23],
 })
 
 function escapeHtml(s: string): string {
@@ -32,27 +32,25 @@ function escapeHtml(s: string): string {
 }
 
 function initialsOf(name: string): string {
-  return (
-    name.trim().split(/\s+/).map((p) => p[0]).join('').slice(0, 2).toUpperCase() || '?'
-  )
+  return name.trim().split(/\s+/).map((p) => p[0]).join('').slice(0, 2).toUpperCase() || '?'
 }
 
 /** Google-Maps-style avatar pin: photo if available, else initials chip. */
 function memberIcon(m: PresenceMember): L.DivIcon {
-  const ring = m.status === 'home' ? '#16a34a' : '#9ca3af'
+  const ring = m.status === 'home' ? '#16a34a' : '#fb923c'
   const inner = m.photoURL
     ? `<img src="${escapeHtml(m.photoURL)}" alt="" referrerpolicy="no-referrer" style="width:100%;height:100%;object-fit:cover;border-radius:9999px;" />`
     : `<div style="width:100%;height:100%;display:flex;align-items:center;justify-content:center;` +
       `border-radius:9999px;background:linear-gradient(135deg,#f5d0a9,#f8e4c9);color:#92400e;` +
-      `font-weight:600;font-size:13px;font-family:system-ui,-apple-system,sans-serif;">${escapeHtml(initialsOf(m.name))}</div>`
+      `font-weight:700;font-size:14px;font-family:system-ui,-apple-system,sans-serif;">${escapeHtml(initialsOf(m.name))}</div>`
   return L.divIcon({
     className: 'presence-pin',
     html:
-      `<div style="width:38px;height:38px;border-radius:9999px;background:#fff;padding:2px;` +
-      `box-sizing:border-box;border:2.5px solid ${ring};box-shadow:0 2px 6px rgba(0,0,0,.3);">${inner}</div>`,
-    iconSize: [38, 38],
-    iconAnchor: [19, 19],
-    popupAnchor: [0, -20],
+      `<div style="width:44px;height:44px;border-radius:9999px;background:#fff;padding:2.5px;` +
+      `box-sizing:border-box;border:3px solid ${ring};box-shadow:0 3px 8px rgba(0,0,0,.28);">${inner}</div>`,
+    iconSize: [44, 44],
+    iconAnchor: [22, 22],
+    popupAnchor: [0, -24],
   })
 }
 
@@ -66,17 +64,25 @@ export type PresenceMember = {
   updatedAt: number | null
 }
 
-/** Frame the map to show home + all member pins. */
-function FitBounds({ points }: { points: [number, number][] }) {
+/** Frame the map to show home + all member pins — once, so it doesn't fight panning. */
+function FitBoundsOnce({ points }: { points: [number, number][] }) {
+  const map = useMap()
+  const done = useRef(false)
+  useEffect(() => {
+    if (done.current || points.length === 0) return
+    done.current = true
+    if (points.length === 1) map.setView(points[0], 16)
+    else map.fitBounds(points, { padding: [48, 48], maxZoom: 16 })
+  }, [points, map])
+  return null
+}
+
+/** Fly to a member when the user taps "locate". */
+function FlyToFocus({ target }: { target: { lat: number; lng: number } | null }) {
   const map = useMap()
   useEffect(() => {
-    if (points.length <= 1) {
-      if (points[0]) map.setView(points[0], 16)
-      return
-    }
-    map.fitBounds(points, { padding: [44, 44], maxZoom: 16 })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(points)])
+    if (target) map.flyTo([target.lat, target.lng], 17, { duration: 0.8 })
+  }, [target?.lat, target?.lng, map])
   return null
 }
 
@@ -84,10 +90,12 @@ export default function PresenceMap({
   home,
   radius,
   members,
+  focus,
 }: {
   home: { lat: number; lng: number }
   radius: number
   members: PresenceMember[]
+  focus?: { lat: number; lng: number } | null
 }) {
   const points: [number, number][] = [
     [home.lat, home.lng],
@@ -99,18 +107,18 @@ export default function PresenceMap({
       center={[home.lat, home.lng]}
       zoom={16}
       scrollWheelZoom={false}
-      className="h-[260px] w-full rounded-2xl z-0"
+      className="h-[320px] w-full rounded-2xl z-0 ring-1 ring-border"
     >
       <TileLayer
-        attribution="&copy; OpenStreetMap contributors"
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+        url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
       />
 
       {/* Home + its presence radius */}
       <Circle
         center={[home.lat, home.lng]}
         radius={radius}
-        pathOptions={{ color: '#b45309', fillColor: '#d97706', fillOpacity: 0.08, weight: 1.5 }}
+        pathOptions={{ color: '#b45309', fillColor: '#d97706', fillOpacity: 0.1, weight: 1.5 }}
       />
       <Marker position={[home.lat, home.lng]} icon={homeDivIcon}>
         <Popup>🏡 Home</Popup>
@@ -131,7 +139,8 @@ export default function PresenceMap({
         </Marker>
       ))}
 
-      <FitBounds points={points} />
+      <FitBoundsOnce points={points} />
+      <FlyToFocus target={focus ?? null} />
     </MapContainer>
   )
 }


### PR DESCRIPTION
Addresses "still not showing anything," plus better visuals and tap-to-locate.

### Why nothing showed (the real bug)
My freshness filter hid pins with a **null timestamp** — but a null `lastGeo.updatedAt` means the Firestore server timestamp is **still pending** right after a write, i.e. the *freshest* pin. So the moment your device updated your location, the filter dropped it. Fixed: only hide **confidently old** fixes (resolved timestamp older than 3h); keep pending/unknown ones. Your own pin should now appear.

### Tap-to-locate
Each member row now has a 📍 button → flies the map to that member (scrolls the map into view + smooth fly-to + zoom). Toast if they have no recent location.

### Cozier visuals
- Clean **CARTO "light"** basemap (minimal, cozy) instead of busy default OSM
- **Taller** map (320px), subtle border
- **Bigger avatar pins** (44px) with softer shadows; warmer "out" ring
- **Fit-once** framing so the map stops re-zooming on every live update

`tsc` + `next build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_