### PR TITLE
fix(map): reliable "Show me" + surface geolocation error

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -336,13 +336,23 @@ export default function HomePage() {
             { merge: true }
           )
           setFocusTarget({ lat: latitude, lng: longitude })
-          toast.success('You’re on the map')
-        } catch {
-          toast.error('Could not update your location')
+          toast.success('You’re on the map 📍')
+        } catch (e) {
+          toast.error(`Couldn’t save location: ${e instanceof Error ? e.message : 'unknown error'}`)
         }
       },
-      () => toast.error('Allow location access to appear on the map'),
-      { enableHighAccuracy: true, maximumAge: 0, timeout: 20_000 }
+      (err) => {
+        const msg =
+          err.code === err.PERMISSION_DENIED
+            ? 'Location is off for Safari — Settings → Privacy → Location Services → Safari Websites → While Using'
+            : err.code === err.POSITION_UNAVAILABLE
+              ? 'Location unavailable right now — try again (better signal helps)'
+              : err.code === err.TIMEOUT
+                ? 'Location timed out — tap again'
+                : 'Could not get your location'
+        toast.error(`${msg} (code ${err.code})`)
+      },
+      { enableHighAccuracy: false, maximumAge: 30_000, timeout: 15_000 }
     )
   }
 


### PR DESCRIPTION
"Show me" wasn't producing a pin and failed silently. Two changes:

1. **More reliable GPS on iOS** — `enableHighAccuracy:true` + `maximumAge:0` frequently hangs or times out in Safari. Switched to a fast low-accuracy fix with a 30s cached fallback and 15s timeout (city-block accuracy is plenty for a presence pin).
2. **Surface the real error** — instead of a generic message, the toast now shows the exact `GeolocationPositionError` (permission denied / position unavailable / timeout, with the numeric code) and any Firestore save error. So we can finally see *why* it fails.

`tsc` + `next build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_