### PR TITLE
revert(auth): same-origin handler caused redirect_uri_mismatch

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -9,25 +9,9 @@ import {
 // DO NOT import getMessaging here at top-level
 import type { Messaging } from 'firebase/messaging'
 
-// Hosts that proxy Firebase's auth handler at /__/auth/* (see vercel.json).
-// On these we use the app's own origin as authDomain so signInWithPopup /
-// signInWithRedirect stay same-origin — avoiding the iOS Safari / ITP
-// cross-domain sign-in loop. Extendable via env for custom domains.
-const SAME_ORIGIN_AUTH_HOSTS = (
-  process.env.NEXT_PUBLIC_SAME_ORIGIN_AUTH_HOSTS || 'abot-ko-na.vercel.app'
-)
-  .split(',')
-  .map((s) => s.trim())
-  .filter(Boolean)
-
-const resolvedAuthDomain =
-  typeof window !== 'undefined' && SAME_ORIGIN_AUTH_HOSTS.includes(window.location.host)
-    ? window.location.host
-    : process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
-
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: resolvedAuthDomain,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
   projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
   storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,

--- a/vercel.json
+++ b/vercel.json
@@ -32,14 +32,6 @@
   ],
   "rewrites": [
     {
-      "source": "/__/auth/:path*",
-      "destination": "https://abot-ko-na.firebaseapp.com/__/auth/:path*"
-    },
-    {
-      "source": "/__/firebase/:path*",
-      "destination": "https://abot-ko-na.firebaseapp.com/__/firebase/:path*"
-    },
-    {
       "source": "/sw.js",
       "destination": "/service-worker.js"
     }


### PR DESCRIPTION
Fixes `Error 400: redirect_uri_mismatch` on Google sign-in.

**Cause:** my same-origin auth fix (#39) set `authDomain` to `abot-ko-na.vercel.app` and proxied `/__/auth/*`. That makes sign-in request a redirect to `https://abot-ko-na.vercel.app/__/auth/handler`, which the Google OAuth client doesn't authorize (it only allows the `firebaseapp.com` handler) → hard rejection. It only appeared to work right after #39 because of a still-valid cached session; clearing the cache forced a real OAuth round-trip and surfaced it.

**Revert:**
- `firebase.ts`: `authDomain` back to `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` (the registered `firebaseapp.com`).
- `vercel.json`: remove the `/__/auth/*` and `/__/firebase/*` rewrites.

The popup-on-mobile fix (#38) stays — it addresses the iOS sign-in loop without needing any Google OAuth config (popup uses the registered `firebaseapp.com` handler and returns the credential via `postMessage` to our own origin).

`tsc` + `next build` pass; `vercel.json` validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_