### PR TITLE
fix(home): family name + empty state after sign-in

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -132,8 +132,9 @@ export default function HomePage() {
   const [hasHomeLocation, setHasHomeLocation] = useState<boolean | null>(null)
   const [homeLoc, setHomeLoc] = useState<{ lat: number; lng: number } | null>(null)
   const [homeRadius, setHomeRadius] = useState<number>(120)
+  const [familyName, setFamilyName] = useState<string | null>(null)
   useEffect(() => {
-    if (!familyId) { setHasHomeLocation(null); setHomeLoc(null); return }
+    if (!familyId) { setHasHomeLocation(null); setHomeLoc(null); setFamilyName(null); return }
 
     const unsub = onSnapshot(
       doc(firestore, 'families', familyId),
@@ -141,6 +142,7 @@ export default function HomePage() {
         const data = snap.data()
         setHasHomeLocation(familyHasHomeLocation(data))
         setHomeLoc(getHomeLocation(data))
+        setFamilyName(((data as any)?.name as string) ?? null)
         const r = (data as any)?.homeRadiusMeters
         setHomeRadius(typeof r === 'number' && Number.isFinite(r) ? Math.max(30, Math.min(1000, r)) : 120)
       },
@@ -379,7 +381,7 @@ export default function HomePage() {
             className="mt-1.5 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
             <span className="inline-flex h-2 w-2 rounded-full bg-primary/70" />
-            {families.find((f) => f.id === familyId)?.name ?? familyId ?? 'No family set'}
+            {families.find((f) => f.id === familyId)?.name ?? familyName ?? (familyId ? 'Loading…' : 'No family set')}
             <span className="underline underline-offset-2">change</span>
           </Link>
         </motion.div>
@@ -403,7 +405,7 @@ export default function HomePage() {
                   </div>
                 ))}
               </>
-            ) : families.length === 0 ? (
+            ) : (!familyId && families.length === 0) ? (
               <div className="flex flex-col items-center text-center space-y-3 py-4">
                 <div className="text-3xl">🏡</div>
                 <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
Fixes the post-sign-in glitch where Home showed the **raw family ID** ("PwMSOf…") and a wrong **"No family yet"** state — even though the family and its map loaded fine.

**Cause:** right after sign-in, `familyId` is available immediately (your saved default), but the `families` *list* subscription hasn't populated yet. Home keyed its name + empty-state off that list, so it briefly thought you had no family.

**Fix:**
- Read the family **name** straight from the `families/{familyId}` doc the page already subscribes to (the same one that loads the map) — so the name shows even before the list resolves.
- Greeting falls back to **"Loading…"**, never the raw ID.
- "No family yet" only shows when there's genuinely **no `familyId`** (not merely an empty list).

`tsc` + `next build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_