### PR TITLE
security fixes + map permission UX + reopen-bug fix

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -53,7 +53,12 @@ service cloud.firestore {
 
     // === FAMILIES ===
     match /families/{familyId} {
-      allow list: if isSignedIn();
+      // Scoped list only: a query may return a family doc only if the requester
+      // is in its members array (the picker queries members array-contains uid).
+      // Prevents enumerating every family + leaking home locations.
+      allow list: if isSignedIn() &&
+        resource.data.members is list &&
+        request.auth.uid in resource.data.members;
 
       allow create: if isSignedIn() &&
         request.resource.data.createdBy == request.auth.uid &&

--- a/src/app/(main)/@family/default.tsx
+++ b/src/app/(main)/@family/default.tsx
@@ -1,0 +1,2 @@
+'use client'
+export default function DefaultFamily() { return null }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -658,7 +658,7 @@ export default function HomePage() {
                   </Button>
                 </div>
                 {locMsg && (
-                  <p className="rounded-lg bg-muted px-3 py-2 text-[11px] leading-snug text-muted-foreground">
+                  <p className={`rounded-lg px-3 py-2 text-[11px] leading-snug ${/code|off|failed|unavailable|timed/i.test(locMsg) ? 'bg-amber-500/10 text-amber-700 dark:text-amber-400' : 'bg-muted text-muted-foreground'}`}>
                     {locMsg} · pins on map: {mapMembers.length}{meOnMap ? ' · you’re shown ✓' : ''}
                   </p>
                 )}

--- a/src/app/api/save-fcm-token/route.ts
+++ b/src/app/api/save-fcm-token/route.ts
@@ -2,7 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export const runtime = 'nodejs';
 
-const ALLOWED_ORIGIN = 'https://example.com'
+// Auth is enforced via the Firebase ID token below; CORS is permissive because
+// there are no cookies (bearer-token auth). Previously a placeholder origin here
+// could 403 legitimate same-origin calls.
+const ALLOWED_ORIGIN = '*'
 
 type Body = { token?: string; userId?: string };
 
@@ -25,13 +28,7 @@ function looksValidToken(t?: string) {
   return true;
 }
 
-export async function OPTIONS(req: NextRequest) {
-  const origin = req.headers.get('origin') || ''
-  if (origin && origin !== ALLOWED_ORIGIN)
-    return new NextResponse(null, {
-      status: 403,
-      headers: { 'access-control-allow-origin': ALLOWED_ORIGIN },
-    })
+export async function OPTIONS(_req: NextRequest) {
   // Allow same-origin callers and preflights cleanly
   return new NextResponse(null, {
     status: 204,
@@ -45,10 +42,6 @@ export async function OPTIONS(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const origin = req.headers.get('origin') || ''
-  if (origin && origin !== ALLOWED_ORIGIN)
-    return json({ ok: false, error: 'forbidden origin' }, 403)
-
   const admin = await import('firebase-admin');
 
   if (!admin.apps.length) {

--- a/src/app/api/upload-screenshot/route.ts
+++ b/src/app/api/upload-screenshot/route.ts
@@ -1,13 +1,15 @@
 import { handleUpload, type HandleUploadBody } from '@vercel/blob/client'
 import { NextResponse } from 'next/server'
 
+export const runtime = 'nodejs'
+
 /**
  * Client-upload token handler for delivery screenshots (Vercel Blob).
  *
- * The browser uploads the file directly to Blob storage using a short-lived
- * token issued here, which avoids the serverless request body size limit and
- * keeps large screenshots off the API route. Requires a Blob store connected
- * to the project (provides the BLOB_READ_WRITE_TOKEN env var).
+ * Requires a valid Firebase ID token (sent by the client as `clientPayload`)
+ * before issuing an upload token — so only signed-in users can upload, not
+ * anonymous callers. Requires a Blob store connected to the project
+ * (BLOB_READ_WRITE_TOKEN) and Firebase admin creds in env.
  */
 export async function POST(request: Request): Promise<NextResponse> {
   const body = (await request.json()) as HandleUploadBody
@@ -16,12 +18,34 @@ export async function POST(request: Request): Promise<NextResponse> {
     const jsonResponse = await handleUpload({
       body,
       request,
-      onBeforeGenerateToken: async () => ({
-        allowedContentTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/gif'],
-        maximumSizeInBytes: 10 * 1024 * 1024, // 10 MB
-        addRandomSuffix: true,
-      }),
-      // No-op: the client writes the resulting URL onto the delivery doc.
+      onBeforeGenerateToken: async (_pathname, clientPayload) => {
+        const admin = await import('firebase-admin')
+        if (!admin.apps.length) {
+          admin.initializeApp({
+            credential: admin.credential.cert({
+              projectId: process.env.FIREBASE_PROJECT_ID,
+              clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+              privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+            }),
+          })
+        }
+
+        if (!clientPayload) throw new Error('Unauthorized: missing auth token')
+        let uid: string
+        try {
+          const decoded = await admin.auth().verifyIdToken(clientPayload)
+          uid = decoded.uid
+        } catch {
+          throw new Error('Unauthorized: invalid auth token')
+        }
+
+        return {
+          allowedContentTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/gif'],
+          maximumSizeInBytes: 10 * 1024 * 1024, // 10 MB
+          addRandomSuffix: true,
+          tokenPayload: JSON.stringify({ uid }),
+        }
+      },
       onUploadCompleted: async () => {},
     })
 

--- a/src/app/components/DeliveryFormDialog.tsx
+++ b/src/app/components/DeliveryFormDialog.tsx
@@ -15,7 +15,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { collection, addDoc, Timestamp, doc, updateDoc, getDocs, deleteDoc, writeBatch } from 'firebase/firestore'
-import { firestore } from '@/lib/firebase'
+import { firestore, auth } from '@/lib/firebase'
 import { createDelivery } from '@/lib/deliveries'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Textarea } from '@/components/ui/textarea'
@@ -244,9 +244,15 @@ export default function DeliveryFormDialog({ open, onOpenChange, familyId, deliv
     }
     setUploading(true)
     try {
+      const idToken = await auth.currentUser?.getIdToken()
+      if (!idToken) {
+        toast.error('Please sign in again to upload')
+        return
+      }
       const result = await upload(file.name, file, {
         access: 'public',
         handleUploadUrl: '/api/upload-screenshot',
+        clientPayload: idToken,
       })
       setScreenshotUrl(result.url)
     } catch (err) {


### PR DESCRIPTION
Applies the security fixes from the review, plus the map permission UX and the reopen-bug fix.

## Security
- **Family enumeration / home-location leak (critical):** `families` list rule now requires the requester be in `members` — no more reading every family's data + home GPS. The picker's `members array-contains` query still works.
- **Unauthenticated upload (medium):** `/api/upload-screenshot` now verifies a Firebase ID token (sent as `clientPayload`) before issuing a Blob token; the client sends `getIdToken()`. Anonymous uploads blocked.
- **CORS placeholder (low):** removed the leftover `example.com` origin gate in `/api/save-fcm-token` (auth is the verified ID token; the placeholder could 403 legit calls).

## Map
- Location-permission failures now show in a **prominent amber callout**. Your screenshot showed `code 1` = iOS **system** Location Services denied (despite Safari's per-site "Allow") — a device setting, not a code bug.

## Reopen bug (blank deep-route on cold open)
- **Root cause:** the `@family` parallel-route slot was missing `default.tsx` (every other slot has one). On a cold load of a non-home route, Next.js couldn't resolve that slot, so the whole route rendered nothing until a soft nav to Home. Added the null `default.tsx`.

`tsc` + `next build` pass.

Note: rules change needs a Firestore deploy (I'll trigger the workflow after merge). Dependency-vuln bumps from the review are deliberately **not** included here (riskier; separate change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bf49wzc2KBAvjo52yXGjP)_